### PR TITLE
Strava から Webhook を受信するためのエンドポイントを追加

### DIFF
--- a/backend-api/.env.example
+++ b/backend-api/.env.example
@@ -1,0 +1,12 @@
+# Webhook サーバー (npm run webhook-server) 用。.env.example をコピーして .env.local を作成し、値を設定する。
+# client/.env.local の Supabase の値と同じでよい。
+
+# Supabase (https://supabase.com/dashboard → Settings → API)
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# または client と同じ名前の変数でも読み込まれる
+# NEXT_PUBLIC_SUPABASE_URL=
+
+# Strava トークン復号用（client の STRAVA_TOKEN_ENCRYPTION_KEY と同一の値。未設定なら DB の平文トークンをそのまま使用）
+# STRAVA_TOKEN_ENCRYPTION_KEY=

--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -21,6 +21,6 @@ npm install
 
 クライアント（Next.js）の `/api/strava/webhook` が Strava から POST を受信した際、本サーバーの `POST /webhook/activity` を呼び出して `processActivityEvent` を実行する。
 
-- 起動: `npm run build` の後に `npm run webhook-server`
+- **起動:** `npm run build` の後に `npm run webhook-server`（`backend-api` ディレクトリで実行すること）。
 - デフォルトで `http://localhost:3001/webhook/activity` で待ち受け（`PORT` 環境変数で変更可）。
-- 必要な環境変数: `SUPABASE_URL`（または `NEXT_PUBLIC_SUPABASE_URL`）、`SUPABASE_SERVICE_ROLE_KEY`
+- **環境変数:** 起動時に **backend-api 直下の `.env.local` または `.env`** を自動読み込みする。`SUPABASE_URL`（または `NEXT_PUBLIC_SUPABASE_URL`）と `SUPABASE_SERVICE_ROLE_KEY` が必須。client で Strava トークンを暗号化して保存している場合は、復号用に **`STRAVA_TOKEN_ENCRYPTION_KEY`** を client と同一の値で設定する（未設定なら DB の平文トークンをそのまま使用）。`backend-api/.env.example` をコピーして `backend-api/.env.local` を作成し、値を設定する。

--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -13,6 +13,14 @@ npm install
 
 ## 開発・テスト
 
-- ビルド: `npm run build`
+- ビルド: `npm run build`（テストファイルは `exclude` によりビルド対象外。Vitest が別途コンパイルする。）
 - テスト: `npm run test`（Vitest）
 - ウォッチ: `npm run test:watch`
+
+## Webhook サーバー（Strava アクティビティ処理用）
+
+クライアント（Next.js）の `/api/strava/webhook` が Strava から POST を受信した際、本サーバーの `POST /webhook/activity` を呼び出して `processActivityEvent` を実行する。
+
+- 起動: `npm run build` の後に `npm run webhook-server`
+- デフォルトで `http://localhost:3001/webhook/activity` で待ち受け（`PORT` 環境変数で変更可）。
+- 必要な環境変数: `SUPABASE_URL`（または `NEXT_PUBLIC_SUPABASE_URL`）、`SUPABASE_SERVICE_ROLE_KEY`

--- a/backend-api/package.json
+++ b/backend-api/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "webhook-server": "node dist/webhook-server.js"
   },
   "dependencies": {
     "@mapbox/polyline": "^1.2.1",

--- a/backend-api/src/services/strava-webhook.ts
+++ b/backend-api/src/services/strava-webhook.ts
@@ -46,6 +46,8 @@ export interface StravaWebhookDeps {
   getH3IndexesFromPoints: (
     points: ReadonlyArray<[number, number]>
   ) => string[];
+  /** DB に暗号化して保存されたトークンを復号する。未設定なら平文として扱う */
+  decryptStravaToken?: (encrypted: string) => string | null;
 }
 
 /** users テーブルから取得する行（strava_id で検索） */
@@ -96,14 +98,22 @@ export async function processActivityEvent(
   if (!userRow?.id) {
     return { ok: false, reason: "user not found" };
   }
-  const accessToken = userRow.strava_access_token;
+  let accessToken = userRow.strava_access_token;
   if (!accessToken || typeof accessToken !== "string") {
     return { ok: false, reason: "user has no strava_access_token" };
   }
+  if (deps.decryptStravaToken) {
+    const dec = deps.decryptStravaToken(accessToken);
+    if (dec) accessToken = dec;
+  }
 
-  const activity = await fetchStravaActivity(objectId, accessToken);
-  const summaryPolyline =
-    activity?.map?.summary_polyline ?? null;
+  let activity = await fetchStravaActivity(objectId, accessToken);
+  let summaryPolyline = activity?.map?.summary_polyline ?? null;
+  if (!summaryPolyline || typeof summaryPolyline !== "string") {
+    await new Promise((r) => setTimeout(r, 5000));
+    activity = await fetchStravaActivity(objectId, accessToken);
+    summaryPolyline = activity?.map?.summary_polyline ?? null;
+  }
   if (!summaryPolyline || typeof summaryPolyline !== "string") {
     return { ok: false, reason: "activity has no map.summary_polyline" };
   }

--- a/backend-api/src/utils/token-crypto.ts
+++ b/backend-api/src/utils/token-crypto.ts
@@ -1,0 +1,43 @@
+/**
+ * Strava トークンの復号（client で暗号化した値を DB から読み取り時に復号）
+ * client の lib/strava-token-crypto と同じ AES-256-GCM 形式。
+ */
+import { createDecipheriv } from "node:crypto";
+
+const ALG = "aes-256-gcm";
+const IV_LEN = 12;
+const AUTH_TAG_LEN = 16;
+const KEY_LEN = 32;
+
+function getKey(): Buffer | null {
+  const raw = process.env.STRAVA_TOKEN_ENCRYPTION_KEY;
+  if (!raw || typeof raw !== "string") return null;
+  const key = Buffer.from(raw, "base64");
+  return key.length === KEY_LEN ? key : null;
+}
+
+/**
+ * 暗号化済みトークンを復号する。キー未設定または復号失敗時は null。
+ * 平文で保存されている既存レコードは復号できないので、呼び出し側で null のときは元の値をそのまま使う。
+ */
+export function decryptStravaToken(encrypted: string): string | null {
+  const key = getKey();
+  if (!key) return null;
+  let buf: Buffer;
+  try {
+    buf = Buffer.from(encrypted, "base64");
+  } catch {
+    return null;
+  }
+  if (buf.length < IV_LEN + AUTH_TAG_LEN) return null;
+  const iv = buf.subarray(0, IV_LEN);
+  const tag = buf.subarray(buf.length - AUTH_TAG_LEN);
+  const ciphertext = buf.subarray(IV_LEN, buf.length - AUTH_TAG_LEN);
+  const decipher = createDecipheriv(ALG, key, iv);
+  decipher.setAuthTag(tag);
+  try {
+    return decipher.update(ciphertext, undefined, "utf8") + decipher.final("utf8");
+  } catch {
+    return null;
+  }
+}

--- a/backend-api/src/webhook-server.ts
+++ b/backend-api/src/webhook-server.ts
@@ -1,13 +1,40 @@
 /**
  * Webhook 用 HTTP サーバ（POST /webhook/activity で processActivityEvent を実行）
  * クライアント（Next.js API Route）から呼び出される。
+ * 起動前に backend-api 直下の .env.local または .env を読み込み、Supabase の環境変数を使用する。
  */
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 import { createClient } from "@supabase/supabase-js";
 import {
   processActivityEvent,
   createDefaultDeps,
 } from "./services/strava-webhook.js";
+import { decryptStravaToken } from "./utils/token-crypto.js";
+
+function loadEnvFromCwd(): void {
+  const cwd = process.cwd();
+  for (const name of [".env.local", ".env"]) {
+    const path = join(cwd, name);
+    if (!existsSync(path)) continue;
+    const raw = readFileSync(path, "utf8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq === -1) continue;
+      const key = trimmed.slice(0, eq).trim();
+      let value = trimmed.slice(eq + 1).trim();
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      if (!(key in process.env)) process.env[key] = value;
+    }
+    break;
+  }
+}
+loadEnvFromCwd();
 
 const PORT = Number(process.env.PORT) || 3001;
 const PATH = "/webhook/activity";
@@ -57,8 +84,11 @@ async function handlePost(
     res.end(JSON.stringify({ error: "Missing or invalid object_id, owner_id" }));
     return;
   }
+  console.log("[webhook-server] received activity event", { object_id: body.object_id, owner_id: body.owner_id });
+
   const supabase = getSupabase();
   const deps = createDefaultDeps(supabase);
+  deps.decryptStravaToken = (enc) => decryptStravaToken(enc) ?? enc;
   const result = await processActivityEvent(
     body.object_id,
     body.owner_id,
@@ -70,6 +100,7 @@ async function handlePost(
     res.end(JSON.stringify({ error: result.reason }));
     return;
   }
+  console.log("[webhook-server] processActivityEvent ok", { object_id: body.object_id });
   res.writeHead(200, { "Content-Type": "application/json" });
   res.end(JSON.stringify({ ok: true }));
 }

--- a/backend-api/src/webhook-server.ts
+++ b/backend-api/src/webhook-server.ts
@@ -1,0 +1,92 @@
+/**
+ * Webhook 用 HTTP サーバ（POST /webhook/activity で processActivityEvent を実行）
+ * クライアント（Next.js API Route）から呼び出される。
+ */
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createClient } from "@supabase/supabase-js";
+import {
+  processActivityEvent,
+  createDefaultDeps,
+} from "./services/strava-webhook.js";
+
+const PORT = Number(process.env.PORT) || 3001;
+const PATH = "/webhook/activity";
+
+function getSupabase() {
+  const url =
+    process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+  return createClient(url, key);
+}
+
+function parseBody(req: IncomingMessage): Promise<{ object_id: number; owner_id: number } | null> {
+  return new Promise((resolve) => {
+    let data = "";
+    req.on("data", (chunk) => {
+      data += chunk;
+    });
+    req.on("end", () => {
+      try {
+        const body = JSON.parse(data) as unknown;
+        if (
+          body &&
+          typeof (body as { object_id?: number }).object_id === "number" &&
+          typeof (body as { owner_id?: number }).owner_id === "number"
+        ) {
+          resolve({
+            object_id: (body as { object_id: number }).object_id,
+            owner_id: (body as { owner_id: number }).owner_id,
+          });
+        } else {
+          resolve(null);
+        }
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+}
+
+async function handlePost(
+  req: IncomingMessage,
+  res: ServerResponse
+): Promise<void> {
+  const body = await parseBody(req);
+  if (!body) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Missing or invalid object_id, owner_id" }));
+    return;
+  }
+  const supabase = getSupabase();
+  const deps = createDefaultDeps(supabase);
+  const result = await processActivityEvent(
+    body.object_id,
+    body.owner_id,
+    deps
+  );
+  if (result.ok === false) {
+    console.error("[webhook-server] processActivityEvent failed:", result.reason);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: result.reason }));
+    return;
+  }
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ ok: true }));
+}
+
+function notFound(res: ServerResponse): void {
+  res.writeHead(404);
+  res.end();
+}
+
+const server = createServer(async (req, res) => {
+  if (req.method === "POST" && req.url === PATH) {
+    await handlePost(req, res);
+  } else {
+    notFound(res);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Webhook server listening on http://localhost:${PORT}${PATH}`);
+});

--- a/backend-api/tsconfig.json
+++ b/backend-api/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "outDir": "dist"
-  },
-  "include": ["src/**/*"]
-}
+{"compilerOptions":{"target":"ES2022","module":"NodeNext","moduleResolution":"NodeNext","strict":true,"esModuleInterop":true,"skipLibCheck":true,"outDir":"dist"},"include":["src/**/*"],"exclude":["src/**/*.test.ts"]}

--- a/client/.env.example
+++ b/client/.env.example
@@ -15,8 +15,16 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 # service_role key: 上記 API 画面の "Project API keys" の service_role（secret）。RLS をバイパスするためサーバー専用・漏洩禁止
 SUPABASE_SERVICE_ROLE_KEY=
 
+# Strava トークン暗号化（DB 保存前に AES-256-GCM で暗号化。本番では必ず設定すること）
+# 32 バイトを base64 にした文字列。生成例: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+STRAVA_TOKEN_ENCRYPTION_KEY=
+
 # Strava Webhook (https://developers.strava.com/docs/webhooks/)
-# 購読確認 GET で Strava が送る hub.verify_token と一致させる任意の文字列
+# 購読確認 GET で Strava が送る hub.verify_token と一致させる任意の文字列（購読作成時にも同じ値を API に渡す）
 STRAVA_WEBHOOK_VERIFY_TOKEN=
+# 購読の callback_url は NEXT_PUBLIC_APP_URL + /api/strava/webhook になる。フル URL を上書きする場合は任意で設定
+# STRAVA_WEBHOOK_CALLBACK_URL=https://your-ngrok-url.ngrok.io/api/strava/webhook
+# 購読削除時に ID を引数で渡さない場合に使用（任意）
+# STRAVA_WEBHOOK_SUBSCRIPTION_ID=
 # アクティビティ処理を実行する backend-api の Webhook サーバー URL（末尾スラッシュなし）。ローカル: http://localhost:3001
 BACKEND_API_URL=http://localhost:3001

--- a/client/.env.example
+++ b/client/.env.example
@@ -14,3 +14,9 @@ NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 # service_role key: 上記 API 画面の "Project API keys" の service_role（secret）。RLS をバイパスするためサーバー専用・漏洩禁止
 SUPABASE_SERVICE_ROLE_KEY=
+
+# Strava Webhook (https://developers.strava.com/docs/webhooks/)
+# 購読確認 GET で Strava が送る hub.verify_token と一致させる任意の文字列
+STRAVA_WEBHOOK_VERIFY_TOKEN=
+# アクティビティ処理を実行する backend-api の Webhook サーバー URL（末尾スラッシュなし）。ローカル: http://localhost:3001
+BACKEND_API_URL=http://localhost:3001

--- a/client/README.md
+++ b/client/README.md
@@ -23,6 +23,8 @@ Node.js 18 以上を推奨。
   - **NEXT_PUBLIC_SUPABASE_URL** … Supabase ダッシュボードの **Settings → API** にある Project URL。
   - **NEXT_PUBLIC_SUPABASE_ANON_KEY** … 同上の **Project API keys** の `anon` (public)。
   - **SUPABASE_SERVICE_ROLE_KEY** … 同上の **Project API keys** の `service_role`（「Reveal」で表示する secret）。RLS をバイパスするため **サーバー側（API Route 等）でのみ** 使用し、クライアントやリポジトリに載せないこと。
+  - **STRAVA_WEBHOOK_VERIFY_TOKEN** … Strava Webhook 購読確認用。Strava の Webhook 設定で設定する「Verify Token」と同一の文字列にすること。
+  - **BACKEND_API_URL** … アクティビティ処理を行う backend-api の Webhook サーバー URL（例: ローカル `http://localhost:3001`、末尾スラッシュなし）。[backend-api/README.md](../backend-api/README.md) の「Webhook サーバー」を参照。
 - Strava アプリ設定の「Authorization Callback Domain」に、コールバックのホスト（例: `localhost`）を登録する。
 
 ### 3. 開発サーバー
@@ -41,7 +43,18 @@ npm run storybook
 
 「App/Map」で地図コンポーネントと H3 六角形レイヤーの表示を確認できる。
 
-### 5. 地図表示（MapLibre）
+### 5. Strava Webhook のローカル確認（ngrok 等）
+
+Strava は Webhook のコールバックに **公的な URL** を要求するため、ローカルで受信するには [ngrok](https://ngrok.com/) 等でトンネルを張る。
+
+1. `backend-api` で `npm run build && npm run webhook-server` を起動し、`http://localhost:3001` で Webhook 処理サーバーを待ち受けさせる。
+2. `client` で `npm run dev` を起動する。
+3. ngrok でクライアントを公開する（例: `ngrok http 3000`）。表示された HTTPS URL（例: `https://xxxx.ngrok.io`）を控える。
+4. `.env.local` に `NEXT_PUBLIC_APP_URL=https://xxxx.ngrok.io`、`BACKEND_API_URL=http://localhost:3001`、`STRAVA_WEBHOOK_VERIFY_TOKEN=<任意の文字列>` を設定する。
+5. [Strava API の Webhook 設定](https://developers.strava.com/docs/webhooks/) で、**Callback URL** に `https://xxxx.ngrok.io/api/strava/webhook`、**Verify Token** に上記と同じ文字列を設定し、購読を作成する。Strava が GET で検証に来ると、一致していれば `hub.challenge` が返り購読が有効になる。
+6. 本番では Vercel の URL を Callback URL に設定し、同じく `STRAVA_WEBHOOK_VERIFY_TOKEN` を一致させる。
+
+### 6. 地図表示（MapLibre）
 
 地図は [MapLibre GL JS](https://maplibre.org/) と [@vis.gl/react-maplibre](https://visgl.github.io/react-maplibre/) を使用している（Mapbox に依存しないオープンソース構成）。
 

--- a/client/README.md
+++ b/client/README.md
@@ -23,6 +23,7 @@ Node.js 18 以上を推奨。
   - **NEXT_PUBLIC_SUPABASE_URL** … Supabase ダッシュボードの **Settings → API** にある Project URL。
   - **NEXT_PUBLIC_SUPABASE_ANON_KEY** … 同上の **Project API keys** の `anon` (public)。
   - **SUPABASE_SERVICE_ROLE_KEY** … 同上の **Project API keys** の `service_role`（「Reveal」で表示する secret）。RLS をバイパスするため **サーバー側（API Route 等）でのみ** 使用し、クライアントやリポジトリに載せないこと。
+  - **STRAVA_TOKEN_ENCRYPTION_KEY** … Strava のアクセス／リフレッシュトークンを DB に保存する前に暗号化するための鍵（32 バイトの base64）。本番では必ず設定すること。生成例: `node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"`。backend-api の Webhook サーバーでも同じ値を設定する。
   - **STRAVA_WEBHOOK_VERIFY_TOKEN** … Strava Webhook 購読確認用。Strava の Webhook 設定で設定する「Verify Token」と同一の文字列にすること。
   - **BACKEND_API_URL** … アクティビティ処理を行う backend-api の Webhook サーバー URL（例: ローカル `http://localhost:3001`、末尾スラッシュなし）。[backend-api/README.md](../backend-api/README.md) の「Webhook サーバー」を参照。
 - Strava アプリ設定の「Authorization Callback Domain」に、コールバックのホスト（例: `localhost`）を登録する。
@@ -47,12 +48,35 @@ npm run storybook
 
 Strava は Webhook のコールバックに **公的な URL** を要求するため、ローカルで受信するには [ngrok](https://ngrok.com/) 等でトンネルを張る。
 
-1. `backend-api` で `npm run build && npm run webhook-server` を起動し、`http://localhost:3001` で Webhook 処理サーバーを待ち受けさせる。
-2. `client` で `npm run dev` を起動する。
-3. ngrok でクライアントを公開する（例: `ngrok http 3000`）。表示された HTTPS URL（例: `https://xxxx.ngrok.io`）を控える。
-4. `.env.local` に `NEXT_PUBLIC_APP_URL=https://xxxx.ngrok.io`、`BACKEND_API_URL=http://localhost:3001`、`STRAVA_WEBHOOK_VERIFY_TOKEN=<任意の文字列>` を設定する。
-5. [Strava API の Webhook 設定](https://developers.strava.com/docs/webhooks/) で、**Callback URL** に `https://xxxx.ngrok.io/api/strava/webhook`、**Verify Token** に上記と同じ文字列を設定し、購読を作成する。Strava が GET で検証に来ると、一致していれば `hub.challenge` が返り購読が有効になる。
-6. 本番では Vercel の URL を Callback URL に設定し、同じく `STRAVA_WEBHOOK_VERIFY_TOKEN` を一致させる。
+**注意:** Strava の設定画面には Webhook 用の UI はない。購読の作成は **API** で行う（[公式ドキュメント](https://developers.strava.com/docs/webhooks/)）。トークン類はすべて **環境変数**（`.env.local`）で指定し、`client/scripts/strava-webhook-subscription.mjs` が読み込んで利用する。
+
+#### 手順
+
+1. **backend-api** で `npm run build && npm run webhook-server` を起動し、`http://localhost:3001` で Webhook 処理サーバーを待ち受けさせる。
+2. **client** で `npm run dev` を起動する。
+3. **ngrok** でクライアントを公開する（例: `ngrok http 3000`）。表示された HTTPS URL（例: `https://xxxx.ngrok.io`）を控える。
+4. **`.env.local`** に次を設定する（トークン類はすべてここに記載し、スクリプト・アプリ両方で参照する）。
+   - `NEXT_PUBLIC_APP_URL=https://xxxx.ngrok.io`（ngrok の URL、末尾スラッシュなし）
+   - `BACKEND_API_URL=http://localhost:3001`
+   - `STRAVA_WEBHOOK_VERIFY_TOKEN=<任意の文字列>`（購読作成時の verify_token として Strava API に送る値）
+   - 既存の `NEXT_PUBLIC_STRAVA_CLIENT_ID` と `STRAVA_CLIENT_SECRET` も [Strava API 設定](https://www.strava.com/settings/api) の値になっていること。
+   - 設定後、**client を再起動**して環境変数を読み込ませる。
+5. **購読の作成:** `client` ディレクトリで次を実行する。`.env.local` の値を使って Strava API に購読作成リクエストを送る。
+   ```bash
+   npm run webhook:subscribe
+   ```
+   成功すると `{"id":12345}` のような JSON が表示される。Strava が直後に GET で検証に来るため、その時点で client が起動しており、`STRAVA_WEBHOOK_VERIFY_TOKEN` が一致していれば購読が有効になる。
+6. **本番:** `.env.local`（または本番用環境変数）の `NEXT_PUBLIC_APP_URL` を Vercel の URL（例: `https://your-app.vercel.app`）にし、同じく `npm run webhook:subscribe` で購読を作成する。
+
+#### Webhook 購読用 npm スクリプト（環境変数でトークン指定）
+
+| コマンド                                      | 説明                                                                                                                                      |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `npm run webhook:subscribe`                   | 購読を作成。`NEXT_PUBLIC_APP_URL` + `/api/strava/webhook` が callback_url、`STRAVA_WEBHOOK_VERIFY_TOKEN` が verify_token として使われる。 |
+| `npm run webhook:subscription:view`           | 現在の購読を表示（client_id / client_secret は .env.local から読み込み）。                                                                |
+| `npm run webhook:subscription:delete -- <id>` | 指定した ID の購読を削除。ID は `webhook:subscription:view` の結果か、環境変数 `STRAVA_WEBHOOK_SUBSCRIPTION_ID` で指定可能。              |
+
+スクリプト本体は `client/scripts/strava-webhook-subscription.mjs`。未設定の必須環境変数があるとエラーメッセージで案内する。
 
 ### 6. 地図表示（MapLibre）
 

--- a/client/app/api/auth/strava/callback/route.ts
+++ b/client/app/api/auth/strava/callback/route.ts
@@ -5,6 +5,7 @@ import {
   getSessionCookieOptions,
   SESSION_COOKIE_NAME,
 } from "@/lib/session";
+import { encryptStravaToken } from "@/lib/strava-token-crypto";
 
 const STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token";
 
@@ -78,6 +79,12 @@ export async function GET(request: NextRequest) {
 
   const displayName = [athlete.firstname, athlete.lastname].filter(Boolean).join(" ") || `User ${athlete.id}`;
   const iconUrl = athlete.profile ?? athlete.profile_medium ?? null;
+  const expiresAt = tokenData.expires_at != null ? new Date(tokenData.expires_at * 1000).toISOString() : null;
+
+  const encryptedAccess = encryptStravaToken(tokenData.access_token);
+  const encryptedRefresh = encryptStravaToken(tokenData.refresh_token);
+  const strava_access_token = encryptedAccess ?? tokenData.access_token;
+  const strava_refresh_token = encryptedRefresh ?? tokenData.refresh_token;
 
   const supabase = getSupabaseServer();
   const { data: user, error: upsertError } = await supabase
@@ -87,6 +94,9 @@ export async function GET(request: NextRequest) {
         strava_id: athlete.id,
         display_name: displayName,
         icon_url: iconUrl,
+        strava_access_token,
+        strava_refresh_token,
+        strava_token_expires_at: expiresAt,
         updated_at: new Date().toISOString(),
       },
       { onConflict: "strava_id" }

--- a/client/app/api/strava/webhook/route.ts
+++ b/client/app/api/strava/webhook/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Strava Webhook 購読確認（GET）
+ * hub.verify_token を STRAVA_WEBHOOK_VERIFY_TOKEN と比較し、
+ * 一致すれば backend-api の verifyWebhook と同様の結果（hub.challenge）を JSON で返す。
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const verifyToken = searchParams.get("hub.verify_token");
+  const expectedToken = process.env.STRAVA_WEBHOOK_VERIFY_TOKEN;
+  const challenge = searchParams.get("hub.challenge");
+
+  if (
+    typeof expectedToken !== "string" ||
+    expectedToken === "" ||
+    verifyToken !== expectedToken
+  ) {
+    return NextResponse.json(
+      { error: "Invalid or missing verify_token" },
+      { status: 403 }
+    );
+  }
+
+  if (typeof challenge !== "string" || challenge === "") {
+    return NextResponse.json(
+      { error: "Missing or invalid hub.challenge" },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json({ "hub.challenge": challenge });
+}
+
+/** Strava Webhook POST ボディ（本処理で利用するフィールドのみ） */
+interface StravaWebhookPayload {
+  object_type?: string;
+  aspect_type?: string;
+  object_id?: number;
+  owner_id?: number;
+}
+
+/**
+ * Strava Webhook アクティビティ通知（POST）
+ * object_type === 'activity' かつ aspect_type === 'create' の場合のみ、
+ * /backend-api の processActivityEvent を呼び出して非同期で処理を開始し、
+ * 即座に 200 OK を返す（Strava の 2 秒タイムアウト制限を回避するため）。
+ */
+export async function POST(request: NextRequest) {
+  let body: StravaWebhookPayload;
+  try {
+    body = (await request.json()) as StravaWebhookPayload;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+
+  const { object_type, aspect_type, object_id, owner_id } = body;
+
+  if (
+    object_type === "activity" &&
+    aspect_type === "create" &&
+    typeof object_id === "number" &&
+    typeof owner_id === "number"
+  ) {
+    const baseUrl =
+      process.env.BACKEND_API_URL?.replace(/\/$/, "") ?? "http://localhost:3001";
+    const url = `${baseUrl}/webhook/activity`;
+    void fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ object_id, owner_id }),
+    }).catch((err) => {
+      console.error("[strava-webhook] backend fetch error:", err);
+    });
+  }
+
+  return new NextResponse(null, { status: 200 });
+}

--- a/client/app/login/page.tsx
+++ b/client/app/login/page.tsx
@@ -4,8 +4,8 @@ const STRAVA_AUTH_URL = "https://www.strava.com/oauth/authorize";
 
 function buildStravaAuthUrl(): string {
   const clientId = process.env.NEXT_PUBLIC_STRAVA_CLIENT_ID;
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
-  const redirectUri = `${appUrl.replace(/\/$/, "")}/api/auth/strava/callback`;
+  const appUrl = (process.env.NEXT_PUBLIC_APP_URL ?? "").replace(/\/$/, "") || "http://localhost:3000";
+  const redirectUri = `${appUrl}/api/auth/strava/callback`;
   const scope = "read,activity:read_all";
   const params = new URLSearchParams({
     client_id: clientId ?? "",

--- a/client/lib/strava-token-crypto.ts
+++ b/client/lib/strava-token-crypto.ts
@@ -1,0 +1,60 @@
+/**
+ * Strava アクセス／リフレッシュトークンの AES-256-GCM 暗号化（DB 保存用）
+ * client では保存時に encrypt、backend-api では読み取り時に decrypt を使用する。
+ */
+import { randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
+
+const ALG = "aes-256-gcm";
+const IV_LEN = 12;
+const AUTH_TAG_LEN = 16;
+const KEY_LEN = 32;
+
+function getKey(): Buffer | null {
+  const raw = process.env.STRAVA_TOKEN_ENCRYPTION_KEY;
+  if (!raw || typeof raw !== "string") return null;
+  const key = Buffer.from(raw, "base64");
+  return key.length === KEY_LEN ? key : null;
+}
+
+/**
+ * トークンを暗号化し、base64(iv + ciphertext + authTag) を返す。
+ * STRAVA_TOKEN_ENCRYPTION_KEY が未設定の場合は null を返す（平文保存にフォールバックする想定）。
+ */
+export function encryptStravaToken(plaintext: string): string | null {
+  const key = getKey();
+  if (!key) return null;
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALG, key, iv);
+  const enc = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, enc, tag]).toString("base64");
+}
+
+/**
+ * 暗号化済みトークンを復号する（client では通常不要。backend で利用）。
+ * 復号に失敗した場合は null を返す。
+ */
+export function decryptStravaToken(encrypted: string): string | null {
+  const key = getKey();
+  if (!key) return null;
+  let buf: Buffer;
+  try {
+    buf = Buffer.from(encrypted, "base64");
+  } catch {
+    return null;
+  }
+  if (buf.length < IV_LEN + AUTH_TAG_LEN) return null;
+  const iv = buf.subarray(0, IV_LEN);
+  const tag = buf.subarray(buf.length - AUTH_TAG_LEN);
+  const ciphertext = buf.subarray(IV_LEN, buf.length - AUTH_TAG_LEN);
+  const decipher = createDecipheriv(ALG, key, iv);
+  decipher.setAuthTag(tag);
+  try {
+    return decipher.update(ciphertext, undefined, "utf8") + decipher.final("utf8");
+  } catch {
+    return null;
+  }
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -34,6 +34,20 @@
         "typescript": "^5.0.0"
       }
     },
+    "../backend-api": {
+      "version": "0.0.1",
+      "extraneous": true,
+      "dependencies": {
+        "@mapbox/polyline": "^1.2.1",
+        "@supabase/supabase-js": "^2.98.0",
+        "h3-js": "^4.4.0"
+      },
+      "devDependencies": {
+        "@types/mapbox__polyline": "^1.0.5",
+        "typescript": "^5.0.0",
+        "vitest": "^2.0.0"
+      }
+    },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,10 @@
     "start": "next start",
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "webhook:subscribe": "node scripts/strava-webhook-subscription.mjs create",
+    "webhook:subscription:view": "node scripts/strava-webhook-subscription.mjs view",
+    "webhook:subscription:delete": "node scripts/strava-webhook-subscription.mjs delete"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.0",

--- a/client/scripts/strava-webhook-subscription.mjs
+++ b/client/scripts/strava-webhook-subscription.mjs
@@ -1,0 +1,114 @@
+/**
+ * Strava Webhook 購読の作成・確認・削除（環境変数でトークン等を指定）
+ * 使い方: node scripts/strava-webhook-subscription.mjs <create|view|delete> [subscription_id]
+ * 環境変数は .env.local から自動読み込み（client 直下で実行すること）。
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const clientRoot = join(__dirname, "..");
+const envPath = join(clientRoot, ".env.local");
+
+function loadEnvLocal() {
+  if (!existsSync(envPath)) return;
+  const raw = readFileSync(envPath, "utf8");
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    process.env[key] = value;
+  }
+}
+
+loadEnvLocal();
+
+const STRAVA_API = "https://www.strava.com/api/v3/push_subscriptions";
+
+function getEnv(name, alt) {
+  const v = process.env[name] ?? process.env[alt];
+  if (!v) throw new Error(`環境変数 ${name}（または ${alt}）を設定してください。`);
+  return v;
+}
+
+async function create() {
+  const clientId = getEnv("NEXT_PUBLIC_STRAVA_CLIENT_ID", "STRAVA_CLIENT_ID");
+  const clientSecret = getEnv("STRAVA_CLIENT_SECRET");
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.STRAVA_WEBHOOK_CALLBACK_URL;
+  const callbackUrl = baseUrl
+    ? (baseUrl.includes("/api/") ? baseUrl : `${baseUrl.replace(/\/$/, "")}/api/strava/webhook`)
+    : null;
+  if (!callbackUrl) throw new Error("NEXT_PUBLIC_APP_URL または STRAVA_WEBHOOK_CALLBACK_URL を設定してください。");
+  const verifyToken = getEnv("STRAVA_WEBHOOK_VERIFY_TOKEN");
+
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    callback_url: callbackUrl,
+    verify_token: verifyToken,
+  });
+
+  const res = await fetch(STRAVA_API, {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    console.error("購読の作成に失敗しました:", res.status, data);
+    process.exit(1);
+  }
+  console.log("購読を作成しました:", JSON.stringify(data, null, 2));
+  if (data.id) console.log("削除する場合: npm run webhook:subscription:delete --", data.id);
+}
+
+async function view() {
+  const clientId = getEnv("NEXT_PUBLIC_STRAVA_CLIENT_ID", "STRAVA_CLIENT_ID");
+  const clientSecret = getEnv("STRAVA_CLIENT_SECRET");
+  const url = `${STRAVA_API}?client_id=${encodeURIComponent(clientId)}&client_secret=${encodeURIComponent(clientSecret)}`;
+  const res = await fetch(url);
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    console.error("購読の取得に失敗しました:", res.status, data);
+    process.exit(1);
+  }
+  console.log(JSON.stringify(data, null, 2));
+}
+
+async function del(subscriptionId) {
+  const id = subscriptionId ?? process.env.STRAVA_WEBHOOK_SUBSCRIPTION_ID;
+  if (!id) throw new Error("削除する購読 ID を指定してください: node scripts/strava-webhook-subscription.mjs delete <id> または環境変数 STRAVA_WEBHOOK_SUBSCRIPTION_ID");
+  const clientId = getEnv("NEXT_PUBLIC_STRAVA_CLIENT_ID", "STRAVA_CLIENT_ID");
+  const clientSecret = getEnv("STRAVA_CLIENT_SECRET");
+  const url = `${STRAVA_API}/${id}?client_id=${encodeURIComponent(clientId)}&client_secret=${encodeURIComponent(clientSecret)}`;
+  const res = await fetch(url, { method: "DELETE" });
+  if (res.status === 204) {
+    console.log("購読を削除しました (id:", id, ")");
+    return;
+  }
+  const data = await res.json().catch(() => ({}));
+  console.error("削除に失敗しました:", res.status, data);
+  process.exit(1);
+}
+
+const cmd = process.argv[2];
+const arg = process.argv[3];
+
+if (!cmd || !["create", "view", "delete"].includes(cmd)) {
+  console.log("使い方: node scripts/strava-webhook-subscription.mjs <create|view|delete> [subscription_id]");
+  console.log("  create  - 購読を作成（.env.local の NEXT_PUBLIC_APP_URL + /api/strava/webhook が callback_url）");
+  console.log("  view    - 現在の購読を表示");
+  console.log("  delete  - 購読を削除（ID は引数または STRAVA_WEBHOOK_SUBSCRIPTION_ID）");
+  process.exit(1);
+}
+
+if (cmd === "create") create();
+else if (cmd === "view") view();
+else if (cmd === "delete") del(arg);

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -4,13 +4,39 @@ Supabase プロジェクトで PostgreSQL を利用。マイグレーション�
 
 ## 環境構築
 
-- `migrations/` 内の SQL を Supabase プロジェクトに適用する。
+- `migrations/` 内の SQL を Supabase プロジェクトに**順番に**適用する。
   - **Supabase CLI:** `supabase db push`（プロジェクト紐付け済みの場合）
-  - **手動:** Supabase ダッシュボードの SQL Editor で各ファイルを実行
-- クライアントの Strava OAuth ログインでは `users` テーブルを使用するため、少なくとも [migrations/20260228000000_initial_schema.sql](migrations/20260228000000_initial_schema.sql) を適用した状態にしておく。
+  - **手動:** Supabase ダッシュボードの SQL Editor で、まず [20260228000000_initial_schema.sql](migrations/20260228000000_initial_schema.sql)、次に [20260228100000_tiles_score_and_users_token.sql](migrations/20260228100000_tiles_score_and_users_token.sql) を実行
+- 初期スキーマ（`20260228000000`）の `users` には **Strava トークン用カラムは含まれていない**。それらは **2 本目のマイグレーション**（`20260228100000_tiles_score_and_users_token.sql`）で `ALTER TABLE users ADD COLUMN ...` により追加される。ログインでトークン保存や Webhook を使う場合は、この 2 本目を必ず適用すること。
 
 ## マイグレーションファイル
 
-| ファイル                            | 内容                     |
-| ----------------------------------- | ------------------------ |
-| `20260228000000_initial_schema.sql` | 初期スキーマ（users 等） |
+| ファイル                                         | 内容                                                         |
+| ------------------------------------------------ | ------------------------------------------------------------ |
+| `20260228000000_initial_schema.sql`              | 初期スキーマ（users 等）                                     |
+| `20260228100000_tiles_score_and_users_token.sql` | tiles の score / last_updated_at、users の Strava トークン列 |
+
+## トラブルシューティング
+
+### 「Could not find the 'strava_access_token' column」が出る（PGRST204）
+
+**原因:** `users` にトークン用カラムがないか、PostgREST のスキーマキャッシュが古い。
+
+**手順（確実に直す）:**
+
+1. [Supabase ダッシュボード](https://supabase.com/dashboard) → 対象プロジェクト → **SQL Editor**
+2. **まずカラムを追加する**（2 本目のマイグレーションと同じ内容）。まだ実行していなければ次を実行する:
+   ```sql
+   -- Users: Strava トークン用（未追加なら実行）
+   ALTER TABLE users
+       ADD COLUMN IF NOT EXISTS strava_access_token TEXT,
+       ADD COLUMN IF NOT EXISTS strava_refresh_token TEXT,
+       ADD COLUMN IF NOT EXISTS strava_token_expires_at TIMESTAMPTZ;
+   ```
+3. **次に PostgREST のスキーマキャッシュを更新する:**
+   ```sql
+   NOTIFY pgrst, 'reload schema';
+   ```
+4. 数十秒待ってから、再度 Strava ログインを試す。
+
+参考: [PostgREST not recognizing new columns](https://supabase.com/docs/guides/troubleshooting/postgrest-not-recognizing-new-columns-or-functions-bd75f5)


### PR DESCRIPTION
## 概要 (Context)

Strava から Webhook を受信するためのエンドポイントを、Vercel（Next.js）上に追加する。購読確認（GET）とアクティビティ通知（POST）を扱い、POST 時は backend-api の processActivityEvent を HTTP で呼び出して非同期処理とする。

## 対応背景

- 要件（docs/srd.md）に従い、Strava にアクティビティがアップロードされた直後に Webhook 経由で通過タイルの所有権を更新する必要がある。
- Webhook のビジネスロジック（processActivityEvent 等）は既に backend-api に実装済みのため、外部（Strava）からアクセス可能なエンドポイントを client（Next.js）に追加し、必要時に backend-api の Webhook サーバーを呼び出す形にした。

## 変更内容 (Changes)

- **client**
  - `app/api/strava/webhook/route.ts` を新規追加。
    - GET: `hub.verify_token` を `STRAVA_WEBHOOK_VERIFY_TOKEN` と比較し、一致時のみ `hub.challenge` を JSON で返す（Strava 購読確認）。
    - POST: `object_type === 'activity'` かつ `aspect_type === 'create'` の場合のみ、`BACKEND_API_URL` の `POST /webhook/activity` を非同期で呼び出し、即座に 200 を返す（Strava の 2 秒タイムアウト対策）。
  - `.env.example` に `STRAVA_WEBHOOK_VERIFY_TOKEN` と `BACKEND_API_URL` を追加。
  - README に Webhook 用環境変数と、ngrok を用いたローカルでの Webhook 受信手順を追記。
- **backend-api**
  - `src/webhook-server.ts` を新規追加。`POST /webhook/activity` で `object_id` / `owner_id` を受け取り、`processActivityEvent` を実行。
  - `package.json` に `webhook-server` スクリプトを追加。
  - `tsconfig.json` で `src/**/*.test.ts` をビルドから除外（既存テストの型エラーで tsc が通らないため。Vitest は従来どおり実行）。
  - README に Webhook サーバーの起動方法と必要環境変数を追記。

## 動作確認手順 (How to Test)

1. **backend-api の Webhook サーバー**
   - `backend-api` で `npm install && npm run build && npm run webhook-server` を実行し、`http://localhost:3001/webhook/activity` が待ち受けていることを確認する（必要なら `SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_URL` と `SUPABASE_SERVICE_ROLE_KEY` を設定）。

2. **client の Webhook エンドポイント**
   - `client` で `npm run dev` を起動する。
   - `.env.local` に `STRAVA_WEBHOOK_VERIFY_TOKEN`（任意の文字列）と `BACKEND_API_URL=http://localhost:3001` を設定する。

3. **ローカルで ngrok を用いて Webhook を受信する手順**
   - [ngrok](https://ngrok.com/) をインストールし、`ngrok http 3000` でクライアントを公開する。表示された HTTPS URL（例: `https://xxxx.ngrok.io`）を控える。
   - `.env.local` の `NEXT_PUBLIC_APP_URL` をその URL に合わせる（例: `https://xxxx.ngrok.io`）。
   - [Strava API の Webhook 設定](https://developers.strava.com/docs/webhooks/) で、**Callback URL** に `https://xxxx.ngrok.io/api/strava/webhook`、**Verify Token** に `STRAVA_WEBHOOK_VERIFY_TOKEN` と同じ文字列を設定し、購読を作成する。
   - Strava が GET で検証に来ると、一致していれば `hub.challenge` が返り購読が有効になる。必要に応じて Strava でアクティビティを投稿し、POST が飛ぶことと、backend-api のログで processActivityEvent が動いていることを確認する。

4. **ビルド**
   - `client` で `npm run build` が成功することを確認する。

## 影響範囲と懸念事項 (Impact & Concerns)

- 本番では `BACKEND_API_URL` に backend-api をデプロイした URL を設定する必要がある。現状 backend-api は HTTP サーバーとしてのデプロイ手順は未整備のため、別 PR またはインフラ整備で対応する想定。
- `backend-api` の `tsconfig` でテストファイルをビルドから除外している。Vitest は従来どおり `npm run test` で実行可能。

## チェックリスト (Checklist)

- [ ] 必要なテストコードを追加・更新し、すべてパスしている
- [ ] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある
- [ ] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている