### PR TITLE
リーダーボードの実装

### DIFF
--- a/client/app/api/groups/[id]/leaderboard/route.ts
+++ b/client/app/api/groups/[id]/leaderboard/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { getSessionUserId } from "@/lib/session";
+import { getSupabaseServer } from "@/lib/supabase";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** GET レスポンスの1件の型（get_group_leaderboard RPC の戻り値） */
+export interface LeaderboardEntry {
+  user_id: string;
+  display_name: string | null;
+  icon_url: string | null;
+  tile_count: string;
+}
+
+/**
+ * GET /api/groups/[id]/leaderboard
+ * 指定グループ内のユーザーごとの獲得タイル数ランキングを返す。
+ * 呼び出し元がそのグループのメンバーである場合のみ実行可能。
+ * 集計は Supabase RPC get_group_leaderboard で DB 側で実施する。
+ */
+export async function GET(_request: Request, { params }: RouteParams) {
+  const userId = await getSessionUserId();
+  if (!userId) {
+    return NextResponse.json(
+      { error: "Unauthorized", message: "ログインが必要です" },
+      { status: 401 }
+    );
+  }
+
+  const { id: groupId } = await params;
+  if (!groupId) {
+    return NextResponse.json(
+      { error: "Bad Request", message: "グループ ID がありません" },
+      { status: 400 }
+    );
+  }
+
+  const supabase = getSupabaseServer();
+
+  const { data: member, error: memberError } = await supabase
+    .from("group_members")
+    .select("group_id")
+    .eq("group_id", groupId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (memberError) {
+    console.error("group_members fetch error:", memberError);
+    return NextResponse.json(
+      { error: "Internal Server Error", message: "確認に失敗しました" },
+      { status: 500 }
+    );
+  }
+
+  if (!member) {
+    return NextResponse.json(
+      { error: "Forbidden", message: "このグループのメンバーではないためランキングを参照できません" },
+      { status: 403 }
+    );
+  }
+
+  const { data: rows, error: rpcError } = await supabase.rpc("get_group_leaderboard", {
+    target_group_id: groupId,
+  });
+
+  if (rpcError) {
+    console.error("get_group_leaderboard RPC error:", rpcError);
+    return NextResponse.json(
+      {
+        error: "Internal Server Error",
+        message: "ランキングの取得に失敗しました",
+        detail: rpcError.message,
+      },
+      { status: 500 }
+    );
+  }
+
+  const list = Array.isArray(rows) ? rows : [];
+  return NextResponse.json(list as LeaderboardEntry[]);
+}

--- a/client/app/api/me/activity-logs/route.ts
+++ b/client/app/api/me/activity-logs/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { getSessionUserId } from "@/lib/session";
+import { getSupabaseServer } from "@/lib/supabase";
+
+/** GET レスポンスの1件の型（グループ名を含む） */
+export interface MyActivityLogEntry {
+  id: string;
+  group_id: string;
+  group_name: string | null;
+  user_id: string;
+  action: string;
+  h3_index: string | null;
+  message: string;
+  created_at: string;
+  user?: {
+    display_name: string | null;
+    icon_url: string | null;
+  } | null;
+}
+
+/**
+ * GET /api/me/activity-logs
+ * ログインユーザーが参加している全グループの activity_logs を新しい順で返す。ヘッダー通知用。
+ */
+export async function GET() {
+  const userId = await getSessionUserId();
+  if (!userId) {
+    return NextResponse.json(
+      { error: "Unauthorized", message: "ログインが必要です" },
+      { status: 401 }
+    );
+  }
+
+  const supabase = getSupabaseServer();
+
+  const { data: memberships, error: memberError } = await supabase
+    .from("group_members")
+    .select("group_id")
+    .eq("user_id", userId);
+
+  if (memberError) {
+    console.error("group_members fetch error:", memberError);
+    return NextResponse.json(
+      { error: "Internal Server Error", message: "取得に失敗しました" },
+      { status: 500 }
+    );
+  }
+
+  const groupIds = (memberships ?? []).map((m) => m.group_id).filter(Boolean);
+  if (groupIds.length === 0) {
+    return NextResponse.json([]);
+  }
+
+  const { data: rows, error: logsError } = await supabase
+    .from("activity_logs")
+    .select(
+      "id, group_id, user_id, action, h3_index, message, created_at, users(display_name, icon_url), groups(name)"
+    )
+    .in("group_id", groupIds)
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (logsError) {
+    console.error("activity_logs fetch error:", logsError);
+    return NextResponse.json(
+      { error: "Internal Server Error", message: "ログの取得に失敗しました", detail: logsError.message },
+      { status: 500 }
+    );
+  }
+
+  const logs: MyActivityLogEntry[] = (rows ?? []).map((r) => {
+    const row = r as {
+      id: string;
+      group_id: string;
+      user_id: string;
+      action: string;
+      h3_index: string | null;
+      message: string;
+      created_at: string;
+      users: { display_name: string | null; icon_url: string | null } | { display_name: string | null; icon_url: string | null }[] | null;
+      groups: { name: string | null } | { name: string | null }[] | null;
+    };
+    const userRow = Array.isArray(row.users) ? row.users[0] ?? null : row.users;
+    const groupRow = Array.isArray(row.groups) ? row.groups[0] ?? null : row.groups;
+    return {
+      id: row.id,
+      group_id: row.group_id,
+      group_name: groupRow?.name ?? null,
+      user_id: row.user_id,
+      action: row.action,
+      h3_index: row.h3_index,
+      message: row.message,
+      created_at: row.created_at,
+      user: userRow ?? null,
+    };
+  });
+
+  return NextResponse.json(logs);
+}

--- a/client/components/molecules/NotificationBell.tsx
+++ b/client/components/molecules/NotificationBell.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Bell } from "lucide-react";
+import { Avatar } from "@/components/atoms/Avatar";
+import type { MyActivityLogEntry } from "@/app/api/me/activity-logs/route";
+
+const POLL_INTERVAL_MS = 30_000;
+const MAX_LOGS = 30;
+const STORAGE_KEY_READ_AT = "strava_hex_notification_read_at";
+
+function getLastReadAt(): number | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const s = localStorage.getItem(STORAGE_KEY_READ_AT);
+    if (!s) return null;
+    const t = new Date(s).getTime();
+    return Number.isNaN(t) ? null : t;
+  } catch {
+    return null;
+  }
+}
+
+function setLastReadAt(ms: number): void {
+  try {
+    localStorage.setItem(STORAGE_KEY_READ_AT, new Date(ms).toISOString());
+  } catch {
+    // ignore
+  }
+}
+
+function formatRelativeTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffSec < 60) return "たった今";
+  if (diffMin < 60) return `${diffMin}分前`;
+  if (diffHour < 24) return `${diffHour}時間前`;
+  if (diffDay < 7) return `${diffDay}日前`;
+  return date.toLocaleDateString("ja-JP", {
+    month: "short",
+    day: "numeric",
+    year: date.getFullYear() !== now.getFullYear() ? "numeric" : undefined,
+  });
+}
+
+/**
+ * ヘッダー用の通知ベル。クリックでドロップダウンを開き、参加グループの Activity Log を表示する（Strava の通知風）。
+ */
+export function NotificationBell() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [logs, setLogs] = useState<MyActivityLogEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastReadAt, setLastReadAtState] = useState<number | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const unreadCount = lastReadAt == null
+    ? logs.length
+    : logs.filter((log) => new Date(log.created_at).getTime() > lastReadAt).length;
+  const showBadge = unreadCount > 0;
+
+  const fetchLogs = useCallback(async () => {
+    setError(null);
+    try {
+      const res = await fetch("/api/me/activity-logs", { credentials: "include" });
+      if (!res.ok) {
+        if (res.status === 401) {
+          setLogs([]);
+          return;
+        }
+        const data = (await res.json()) as { message?: string };
+        setError(data.message ?? "取得に失敗しました");
+        setLogs([]);
+        return;
+      }
+      const data = (await res.json()) as MyActivityLogEntry[];
+      setLogs(Array.isArray(data) ? data.slice(0, MAX_LOGS) : []);
+    } catch {
+      setError("取得に失敗しました");
+      setLogs([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    setLastReadAtState(getLastReadAt());
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      setLoading(true);
+      fetchLogs();
+      const interval = setInterval(fetchLogs, POLL_INTERVAL_MS);
+      return () => clearInterval(interval);
+    }
+    fetchLogs();
+    const interval = setInterval(fetchLogs, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [isOpen, fetchLogs]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const readAt = Date.now();
+    setLastReadAt(readAt);
+    setLastReadAtState(readAt);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("click", handleClickOutside);
+    return () => document.removeEventListener("click", handleClickOutside);
+  }, [isOpen]);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setIsOpen((prev) => !prev);
+        }}
+        className="relative flex items-center justify-center rounded-full p-2 text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 focus:outline-none focus:ring-2 focus:ring-zinc-300"
+        aria-label={isOpen ? "通知を閉じる" : "通知を開く"}
+        aria-expanded={isOpen}
+      >
+        <Bell className="h-5 w-5" aria-hidden />
+        {showBadge && (
+          <span
+            className="absolute -right-0.5 -top-0.5 flex min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1.5 py-0.5 text-xs font-bold leading-none text-white"
+            aria-hidden
+          >
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div
+          className="absolute right-0 top-full z-50 mt-1 w-80 max-h-[min(24rem,70vh)] overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg"
+          role="dialog"
+          aria-label="通知"
+        >
+          <div className="border-b border-gray-200 px-3 py-2">
+            <h2 className="text-sm font-semibold text-gray-800">通知</h2>
+          </div>
+          <div className="overflow-y-auto max-h-[min(22rem,calc(70vh-2.5rem))]">
+            {loading && logs.length === 0 ? (
+              <div className="flex items-center justify-center py-8 text-sm text-zinc-500">
+                読み込み中…
+              </div>
+            ) : error ? (
+              <div className="px-3 py-4 text-sm text-amber-700">{error}</div>
+            ) : logs.length === 0 ? (
+              <div className="px-3 py-8 text-center text-sm text-zinc-500">
+                まだ通知はありません
+              </div>
+            ) : (
+              <ul className="divide-y divide-gray-100">
+                {logs.map((log) => (
+                  <li key={log.id} className="px-3 py-2.5">
+                    <div className="flex gap-2.5">
+                      <Avatar
+                        src={log.user?.icon_url ?? null}
+                        alt=""
+                        size="sm"
+                        className="shrink-0 mt-0.5"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm text-gray-900">{log.message}</p>
+                        <p className="mt-0.5 flex items-center gap-1.5 text-xs text-zinc-500">
+                          {log.group_name && (
+                            <span className="truncate">{log.group_name}</span>
+                          )}
+                          <span>{formatRelativeTime(log.created_at)}</span>
+                        </p>
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/components/molecules/index.ts
+++ b/client/components/molecules/index.ts
@@ -1,1 +1,2 @@
 export { UserProfileBadge } from "./UserProfileBadge";
+export { NotificationBell } from "./NotificationBell";

--- a/client/components/organisms/ActivityTimeline.tsx
+++ b/client/components/organisms/ActivityTimeline.tsx
@@ -14,6 +14,8 @@ export interface ActivityTimelineProps {
   initialLogs?: ActivityLogEntry[] | null;
   /** 初期表示でパネルを開くか。デフォルトは false（閉じる） */
   defaultOpen?: boolean;
+  /** true の場合は親の aside 内に埋め込み表示（外側の aside を描画しない） */
+  embedded?: boolean;
 }
 
 function formatRelativeTime(isoString: string): string {
@@ -32,7 +34,7 @@ function formatRelativeTime(isoString: string): string {
   return date.toLocaleDateString("ja-JP", { month: "short", day: "numeric", year: date.getFullYear() !== now.getFullYear() ? "numeric" : undefined });
 }
 
-export function ActivityTimeline({ groupId, initialLogs, defaultOpen = false }: ActivityTimelineProps) {
+export function ActivityTimeline({ groupId, initialLogs, defaultOpen = false, embedded = false }: ActivityTimelineProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const [logs, setLogs] = useState<ActivityLogEntry[]>(initialLogs ?? []);
   const [error, setError] = useState<string | null>(null);
@@ -91,23 +93,35 @@ export function ActivityTimeline({ groupId, initialLogs, defaultOpen = false }: 
   }, [groupId, fetchLogs, initialLogs]);
 
   if (groupId == null) {
-    return (
-      <aside
-        className="absolute right-0 top-0 z-10 flex h-full w-80 max-w-[85vw] flex-col border-l border-gray-200 bg-white/95 shadow-lg backdrop-blur sm:w-96"
-        aria-label="Activity Log"
-      >
+    const content = (
+      <>
         <div className="border-b border-gray-200 px-4 py-3">
           <h2 className="text-sm font-semibold text-gray-800">Activity Log</h2>
         </div>
         <div className="flex flex-1 items-center justify-center p-4 text-center text-sm text-gray-500">
           グループに参加するとタイムラインが表示されます
         </div>
+      </>
+    );
+    if (embedded) {
+      return (
+        <div className="flex flex-1 flex-col min-h-0" aria-label="Activity Log">
+          {content}
+        </div>
+      );
+    }
+    return (
+      <aside
+        className="absolute right-0 top-0 z-10 flex h-full w-80 max-w-[85vw] flex-col border-l border-gray-200 bg-white/95 shadow-lg backdrop-blur sm:w-96"
+        aria-label="Activity Log"
+      >
+        {content}
       </aside>
     );
   }
 
   if (!isOpen) {
-    return (
+    const button = (
       <button
         type="button"
         onClick={() => setIsOpen(true)}
@@ -118,13 +132,28 @@ export function ActivityTimeline({ groupId, initialLogs, defaultOpen = false }: 
         <List className="h-5 w-5 text-gray-600" aria-hidden />
       </button>
     );
+    if (embedded) {
+      return (
+        <div className="flex flex-1 flex-col min-h-0" aria-label="Activity Log">
+          <div className="flex flex-1 items-center justify-end">
+            <button
+              type="button"
+              onClick={() => setIsOpen(true)}
+              className="flex items-center justify-center rounded-l-lg border border-r-0 border-gray-200 bg-white/95 p-2.5 shadow-md backdrop-blur transition hover:bg-gray-50"
+              aria-label="Activity Log を開く"
+              title="Activity Log を開く"
+            >
+              <List className="h-5 w-5 text-gray-600" aria-hidden />
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return button;
   }
 
-  return (
-    <aside
-      className="absolute right-0 top-0 z-10 flex h-full w-80 max-w-[85vw] flex-col border-l border-gray-200 bg-white/95 shadow-lg backdrop-blur sm:w-96"
-      aria-label="Activity Log"
-    >
+  const openContent = (
+    <>
       <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
         <h2 className="text-sm font-semibold text-gray-800">Activity Log</h2>
         <button
@@ -181,6 +210,23 @@ export function ActivityTimeline({ groupId, initialLogs, defaultOpen = false }: 
           </ul>
         )}
       </div>
+    </>
+  );
+
+  if (embedded) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col" aria-label="Activity Log">
+        {openContent}
+      </div>
+    );
+  }
+
+  return (
+    <aside
+      className="absolute right-0 top-0 z-10 flex h-full w-80 max-w-[85vw] flex-col border-l border-gray-200 bg-white/95 shadow-lg backdrop-blur sm:w-96"
+      aria-label="Activity Log"
+    >
+      {openContent}
     </aside>
   );
 }

--- a/client/components/organisms/ActivityTimeline.tsx
+++ b/client/components/organisms/ActivityTimeline.tsx
@@ -16,6 +16,10 @@ export interface ActivityTimelineProps {
   defaultOpen?: boolean;
   /** true の場合は親の aside 内に埋め込み表示（外側の aside を描画しない） */
   embedded?: boolean;
+  /** 制御用。指定時は open で開閉を制御し、onOpenChange で通知する */
+  open?: boolean;
+  /** 開閉状態が変わったときに呼ばれる（制御用） */
+  onOpenChange?: (open: boolean) => void;
 }
 
 function formatRelativeTime(isoString: string): string {
@@ -34,8 +38,11 @@ function formatRelativeTime(isoString: string): string {
   return date.toLocaleDateString("ja-JP", { month: "short", day: "numeric", year: date.getFullYear() !== now.getFullYear() ? "numeric" : undefined });
 }
 
-export function ActivityTimeline({ groupId, initialLogs, defaultOpen = false, embedded = false }: ActivityTimelineProps) {
-  const [isOpen, setIsOpen] = useState(defaultOpen);
+export function ActivityTimeline({ groupId, initialLogs, defaultOpen = false, embedded = false, open: controlledOpen, onOpenChange }: ActivityTimelineProps) {
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isControlled = controlledOpen !== undefined && onOpenChange !== undefined;
+  const isOpen = isControlled ? controlledOpen : internalOpen;
+  const setOpen = isControlled ? (value: boolean) => onOpenChange(value) : setInternalOpen;
   const [logs, setLogs] = useState<ActivityLogEntry[]>(initialLogs ?? []);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(initialLogs === undefined);
@@ -124,7 +131,7 @@ export function ActivityTimeline({ groupId, initialLogs, defaultOpen = false, em
     const button = (
       <button
         type="button"
-        onClick={() => setIsOpen(true)}
+        onClick={() => setOpen(true)}
         className="absolute right-0 top-20 z-10 flex items-center justify-center rounded-l-lg border border-r-0 border-gray-200 bg-white/95 p-2.5 shadow-md backdrop-blur transition hover:bg-gray-50"
         aria-label="Activity Log を開く"
         title="Activity Log を開く"
@@ -134,12 +141,12 @@ export function ActivityTimeline({ groupId, initialLogs, defaultOpen = false, em
     );
     if (embedded) {
       return (
-        <div className="flex flex-1 flex-col min-h-0" aria-label="Activity Log">
-          <div className="flex flex-1 items-center justify-end">
+        <div className="flex shrink-0 flex-col overflow-hidden rounded-bl-lg border-b border-gray-200 py-1" aria-label="Activity Log">
+          <div className="flex justify-end">
             <button
               type="button"
-              onClick={() => setIsOpen(true)}
-              className="flex items-center justify-center rounded-l-lg border border-r-0 border-gray-200 bg-white/95 p-2.5 shadow-md backdrop-blur transition hover:bg-gray-50"
+              onClick={() => setOpen(true)}
+              className="flex items-center justify-center rounded-bl-lg border-r border-gray-200 bg-white/95 p-2.5 shadow-md backdrop-blur transition hover:bg-gray-100 focus:outline-none"
               aria-label="Activity Log を開く"
               title="Activity Log を開く"
             >
@@ -158,7 +165,7 @@ export function ActivityTimeline({ groupId, initialLogs, defaultOpen = false, em
         <h2 className="text-sm font-semibold text-gray-800">Activity Log</h2>
         <button
           type="button"
-          onClick={() => setIsOpen(false)}
+          onClick={() => setOpen(false)}
           className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
           aria-label="Activity Log を閉じる"
           title="閉じる"

--- a/client/components/organisms/GroupMapView.tsx
+++ b/client/components/organisms/GroupMapView.tsx
@@ -19,6 +19,9 @@ export interface GroupMapViewProps {
 export function GroupMapView({ memberships }: GroupMapViewProps) {
   const firstGroupId = memberships[0]?.group_id ?? null;
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(firstGroupId);
+  const [leaderboardOpen, setLeaderboardOpen] = useState(false);
+  const [logOpen, setLogOpen] = useState(false);
+  const bothClosed = !leaderboardOpen && !logOpen;
 
   if (memberships.length === 0) {
     return (
@@ -50,9 +53,22 @@ export function GroupMapView({ memberships }: GroupMapViewProps) {
         </select>
       </div>
       <Map groupId={selectedGroupId} />
-      <aside className="absolute right-0 top-0 z-10 flex h-full w-80 max-w-[85vw] flex-col border-l border-gray-200 bg-white/95 shadow-lg backdrop-blur sm:w-96">
-        <Leaderboard groupId={selectedGroupId} />
-        <ActivityTimeline groupId={selectedGroupId} embedded />
+      <aside
+        className={`absolute right-0 top-0 z-10 flex flex-col border-l border-gray-200 bg-white/95 shadow-lg backdrop-blur ${
+          bothClosed ? "rounded-l-lg overflow-hidden" : "h-full w-80 max-w-[85vw] sm:w-96"
+        }`}
+      >
+        <Leaderboard
+          groupId={selectedGroupId}
+          open={leaderboardOpen}
+          onOpenChange={setLeaderboardOpen}
+        />
+        <ActivityTimeline
+          groupId={selectedGroupId}
+          embedded
+          open={logOpen}
+          onOpenChange={setLogOpen}
+        />
       </aside>
     </div>
   );

--- a/client/components/organisms/GroupMapView.tsx
+++ b/client/components/organisms/GroupMapView.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Map } from "./Map";
 import { ActivityTimeline } from "./ActivityTimeline";
+import { Leaderboard } from "./Leaderboard";
 
 export interface MembershipItem {
   group_id: string;
@@ -49,7 +50,10 @@ export function GroupMapView({ memberships }: GroupMapViewProps) {
         </select>
       </div>
       <Map groupId={selectedGroupId} />
-      <ActivityTimeline groupId={selectedGroupId} />
+      <aside className="absolute right-0 top-0 z-10 flex h-full w-80 max-w-[85vw] flex-col border-l border-gray-200 bg-white/95 shadow-lg backdrop-blur sm:w-96">
+        <Leaderboard groupId={selectedGroupId} />
+        <ActivityTimeline groupId={selectedGroupId} embedded />
+      </aside>
     </div>
   );
 }

--- a/client/components/organisms/GroupMapView.tsx
+++ b/client/components/organisms/GroupMapView.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { Map } from "./Map";
-import { ActivityTimeline } from "./ActivityTimeline";
 import { Leaderboard } from "./Leaderboard";
 
 export interface MembershipItem {
@@ -20,8 +19,7 @@ export function GroupMapView({ memberships }: GroupMapViewProps) {
   const firstGroupId = memberships[0]?.group_id ?? null;
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(firstGroupId);
   const [leaderboardOpen, setLeaderboardOpen] = useState(false);
-  const [logOpen, setLogOpen] = useState(false);
-  const bothClosed = !leaderboardOpen && !logOpen;
+  const panelClosed = !leaderboardOpen;
 
   if (memberships.length === 0) {
     return (
@@ -55,19 +53,13 @@ export function GroupMapView({ memberships }: GroupMapViewProps) {
       <Map groupId={selectedGroupId} />
       <aside
         className={`absolute right-0 top-0 z-10 flex flex-col border-l border-gray-200 bg-white/95 shadow-lg backdrop-blur ${
-          bothClosed ? "rounded-l-lg overflow-hidden" : "h-full w-80 max-w-[85vw] sm:w-96"
+          panelClosed ? "rounded-l-lg overflow-hidden" : "h-full w-80 max-w-[85vw] sm:w-96"
         }`}
       >
         <Leaderboard
           groupId={selectedGroupId}
           open={leaderboardOpen}
           onOpenChange={setLeaderboardOpen}
-        />
-        <ActivityTimeline
-          groupId={selectedGroupId}
-          embedded
-          open={logOpen}
-          onOpenChange={setLogOpen}
         />
       </aside>
     </div>

--- a/client/components/organisms/Header.tsx
+++ b/client/components/organisms/Header.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { getSessionUserId } from "@/lib/session";
 import { getSupabaseServer } from "@/lib/supabase";
 import { LogoLink, StravaConnectButton, LogoutButton } from "@/components/atoms";
-import { UserProfileBadge } from "@/components/molecules";
+import { UserProfileBadge, NotificationBell } from "@/components/molecules";
 
 export interface HeaderUser {
   displayName: string | null;
@@ -39,6 +39,7 @@ export function HeaderView({ user }: { user: HeaderUser | null }) {
               >
                 作成
               </Link>
+              <NotificationBell />
               <UserProfileBadge
                 displayName={user.displayName}
                 iconUrl={user.iconUrl}

--- a/client/components/organisms/Leaderboard.stories.tsx
+++ b/client/components/organisms/Leaderboard.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Leaderboard } from "./Leaderboard";
+import type { LeaderboardEntry } from "@/app/api/groups/[id]/leaderboard/route";
+
+const meta: Meta<typeof Leaderboard> = {
+  component: Leaderboard,
+  title: "Organisms/Leaderboard",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "320px", border: "1px solid #e5e7eb", borderRadius: "4px", overflow: "hidden" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof Leaderboard>;
+
+/** グループ未選択時（グループに参加すると…のメッセージ表示） */
+export const NoGroup: Story = {
+  args: {
+    groupId: null,
+  },
+};
+
+/** ダミーデータを注入してランキングの見た目を確認（1〜3位の王冠装飾付き） */
+function getMockEntries(): LeaderboardEntry[] {
+  return [
+    { user_id: "u1", display_name: "山田太郎", icon_url: null, tile_count: "42" },
+    { user_id: "u2", display_name: "佐藤花子", icon_url: null, tile_count: "28" },
+    { user_id: "u3", display_name: "ランナー", icon_url: null, tile_count: "15" },
+    { user_id: "u4", display_name: "四郎", icon_url: null, tile_count: "7" },
+    { user_id: "u5", display_name: "五郎", icon_url: null, tile_count: "3" },
+  ];
+}
+
+export const WithMockEntries: Story = {
+  args: {
+    groupId: "00000000-0000-0000-0000-000000000001",
+    initialEntries: getMockEntries(),
+  },
+};
+
+/** グループ指定あり（API から取得するため、プレビュー時は空 or 読み込み表示） */
+export const WithGroup: Story = {
+  args: {
+    groupId: "00000000-0000-0000-0000-000000000001",
+  },
+};

--- a/client/components/organisms/Leaderboard.tsx
+++ b/client/components/organisms/Leaderboard.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Crown, Trophy } from "lucide-react";
+import { Avatar } from "@/components/atoms/Avatar";
+import type { LeaderboardEntry } from "@/app/api/groups/[id]/leaderboard/route";
+
+export interface LeaderboardProps {
+  /** 表示するランキングのグループID。null の場合はプレースホルダーのみ表示 */
+  groupId: string | null;
+  /** Storybook 等で視覚確認するためのダミーデータ。指定時は API フェッチを行わない */
+  initialEntries?: LeaderboardEntry[] | null;
+}
+
+function RankCrown({ rank }: { rank: number }) {
+  if (rank === 1) {
+    return (
+      <span className="text-amber-500" aria-hidden>
+        <Crown className="h-5 w-5" fill="currentColor" />
+      </span>
+    );
+  }
+  if (rank === 2) {
+    return (
+      <span className="text-gray-400" aria-hidden>
+        <Crown className="h-4 w-4" fill="currentColor" />
+      </span>
+    );
+  }
+  if (rank === 3) {
+    return (
+      <span className="text-amber-700" aria-hidden>
+        <Crown className="h-4 w-4" fill="currentColor" />
+      </span>
+    );
+  }
+  return null;
+}
+
+export function Leaderboard({ groupId, initialEntries }: LeaderboardProps) {
+  const [entries, setEntries] = useState<LeaderboardEntry[]>(initialEntries ?? []);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(initialEntries === undefined);
+
+  const fetchLeaderboard = useCallback(async () => {
+    if (!groupId) {
+      setEntries([]);
+      setLoading(false);
+      return;
+    }
+    setError(null);
+    try {
+      const res = await fetch(`/api/groups/${encodeURIComponent(groupId)}/leaderboard`, {
+        credentials: "include",
+      });
+      if (!res.ok) {
+        if (res.status === 401 || res.status === 403) {
+          setEntries([]);
+          return;
+        }
+        const data = (await res.json()) as { message?: string };
+        setError(data.message ?? "ランキングの取得に失敗しました");
+        setEntries([]);
+        return;
+      }
+      const data = (await res.json()) as LeaderboardEntry[];
+      setEntries(Array.isArray(data) ? data : []);
+    } catch {
+      setError("ランキングの取得に失敗しました");
+      setEntries([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [groupId]);
+
+  useEffect(() => {
+    if (initialEntries !== undefined && initialEntries !== null) {
+      setEntries(initialEntries);
+      setLoading(false);
+      return;
+    }
+    if (!groupId) {
+      setEntries([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    fetchLeaderboard();
+  }, [groupId, initialEntries, fetchLeaderboard]);
+
+  if (groupId == null) {
+    return (
+      <div className="border-b border-gray-200 px-4 py-3" aria-label="リーダーボード">
+        <h2 className="text-sm font-semibold text-gray-800">ランキング</h2>
+        <div className="mt-2 text-center text-sm text-gray-500">
+          グループに参加するとランキングが表示されます
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-b border-gray-200 px-4 py-3" aria-label="リーダーボード">
+      <h2 className="flex items-center gap-2 text-sm font-semibold text-gray-800">
+        <Trophy className="h-4 w-4 text-amber-500" aria-hidden />
+        ランキング
+      </h2>
+      <div className="mt-2 max-h-64 overflow-y-auto">
+        {loading && entries.length === 0 ? (
+          <div className="flex items-center justify-center py-6 text-sm text-gray-500">
+            読み込み中…
+          </div>
+        ) : error ? (
+          <div className="py-2 text-sm text-amber-700">{error}</div>
+        ) : entries.length === 0 ? (
+          <div className="py-4 text-center text-sm text-gray-500">
+            まだタイルがありません
+          </div>
+        ) : (
+          <ol className="space-y-1.5">
+            {entries.map((entry, index) => {
+              const rank = index + 1;
+              const tileCount = typeof entry.tile_count === "string" ? entry.tile_count : String(entry.tile_count ?? 0);
+              return (
+                <li
+                  key={entry.user_id}
+                  className={`flex items-center gap-2 rounded-lg px-2 py-1.5 ${
+                    rank <= 3 ? "bg-gray-50" : ""
+                  }`}
+                >
+                  <span className="flex w-6 shrink-0 items-center justify-center">
+                    {rank <= 3 ? (
+                      <RankCrown rank={rank} />
+                    ) : (
+                      <span className="text-xs font-medium text-gray-500" aria-label={`${rank}位`}>
+                        {rank}
+                      </span>
+                    )}
+                  </span>
+                  {rank <= 3 && (
+                    <span className="w-5 shrink-0 text-right text-xs font-bold text-gray-600">
+                      {rank}
+                    </span>
+                  )}
+                  <Avatar
+                    src={entry.icon_url ?? null}
+                    alt=""
+                    size="sm"
+                    className="shrink-0"
+                  />
+                  <span className="min-w-0 flex-1 truncate text-sm text-gray-900">
+                    {entry.display_name || "名前なし"}
+                  </span>
+                  <span className="shrink-0 text-sm font-semibold text-green-700" aria-label={`${tileCount}タイル`}>
+                    {tileCount}
+                    <span className="ml-0.5 text-xs font-normal text-gray-500">タイル</span>
+                  </span>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/components/organisms/Leaderboard.tsx
+++ b/client/components/organisms/Leaderboard.tsx
@@ -10,6 +10,12 @@ export interface LeaderboardProps {
   groupId: string | null;
   /** Storybook 等で視覚確認するためのダミーデータ。指定時は API フェッチを行わない */
   initialEntries?: LeaderboardEntry[] | null;
+  /** 初期表示でパネルを開くか。デフォルトは true（開く） */
+  defaultOpen?: boolean;
+  /** 制御用。指定時は open で開閉を制御し、onOpenChange で通知する */
+  open?: boolean;
+  /** 開閉状態が変わったときに呼ばれる（制御用） */
+  onOpenChange?: (open: boolean) => void;
 }
 
 function RankCrown({ rank }: { rank: number }) {
@@ -37,7 +43,11 @@ function RankCrown({ rank }: { rank: number }) {
   return null;
 }
 
-export function Leaderboard({ groupId, initialEntries }: LeaderboardProps) {
+export function Leaderboard({ groupId, initialEntries, defaultOpen = true, open: controlledOpen, onOpenChange }: LeaderboardProps) {
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isControlled = controlledOpen !== undefined && onOpenChange !== undefined;
+  const isOpen = isControlled ? controlledOpen : internalOpen;
+  const setOpen = isControlled ? (value: boolean) => onOpenChange(value) : setInternalOpen;
   const [entries, setEntries] = useState<LeaderboardEntry[]>(initialEntries ?? []);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(initialEntries === undefined);
@@ -90,7 +100,7 @@ export function Leaderboard({ groupId, initialEntries }: LeaderboardProps) {
 
   if (groupId == null) {
     return (
-      <div className="border-b border-gray-200 px-4 py-3" aria-label="リーダーボード">
+      <div className="shrink-0 border-b border-gray-200 px-4 py-3" aria-label="リーダーボード">
         <h2 className="text-sm font-semibold text-gray-800">ランキング</h2>
         <div className="mt-2 text-center text-sm text-gray-500">
           グループに参加するとランキングが表示されます
@@ -99,12 +109,39 @@ export function Leaderboard({ groupId, initialEntries }: LeaderboardProps) {
     );
   }
 
+  if (!isOpen) {
+    return (
+      <div className="flex shrink-0 justify-end overflow-hidden rounded-tl-lg border-b border-gray-200 py-1" aria-label="リーダーボード">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="flex items-center justify-center rounded-tl-lg border-r border-gray-200 bg-white/95 p-2.5 shadow-md backdrop-blur transition hover:bg-gray-100 focus:outline-none"
+          aria-label="ランキングを開く"
+          title="ランキングを開く"
+        >
+          <Trophy className="h-5 w-5 text-amber-500" aria-hidden />
+        </button>
+      </div>
+    );
+  }
+
   return (
-    <div className="border-b border-gray-200 px-4 py-3" aria-label="リーダーボード">
-      <h2 className="flex items-center gap-2 text-sm font-semibold text-gray-800">
-        <Trophy className="h-4 w-4 text-amber-500" aria-hidden />
-        ランキング
-      </h2>
+    <div className="shrink-0 border-b border-gray-200 px-4 py-3" aria-label="リーダーボード">
+      <div className="flex items-center justify-between">
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-gray-800">
+          <Trophy className="h-4 w-4 text-amber-500" aria-hidden />
+          ランキング
+        </h2>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+          aria-label="ランキングを閉じる"
+          title="閉じる"
+        >
+          <span className="text-lg leading-none" aria-hidden>×</span>
+        </button>
+      </div>
       <div className="mt-2 max-h-64 overflow-y-auto">
         {loading && entries.length === 0 ? (
           <div className="flex items-center justify-center py-6 text-sm text-gray-500">

--- a/client/components/organisms/Leaderboard.tsx
+++ b/client/components/organisms/Leaderboard.tsx
@@ -111,11 +111,11 @@ export function Leaderboard({ groupId, initialEntries, defaultOpen = true, open:
 
   if (!isOpen) {
     return (
-      <div className="flex shrink-0 justify-end overflow-hidden rounded-tl-lg border-b border-gray-200 py-1" aria-label="リーダーボード">
+      <div className="flex shrink-0 justify-end overflow-hidden rounded-l-lg border-b border-gray-200 py-1" aria-label="リーダーボード">
         <button
           type="button"
           onClick={() => setOpen(true)}
-          className="flex items-center justify-center rounded-tl-lg border-r border-gray-200 bg-white/95 p-2.5 shadow-md backdrop-blur transition hover:bg-gray-100 focus:outline-none"
+          className="flex items-center justify-center rounded-l-lg border-r border-gray-200 bg-white/95 p-2.5 shadow-md backdrop-blur transition hover:bg-gray-100 focus:outline-none"
           aria-label="ランキングを開く"
           title="ランキングを開く"
         >

--- a/client/components/organisms/index.ts
+++ b/client/components/organisms/index.ts
@@ -2,6 +2,8 @@ export { ActivityTimeline } from "./ActivityTimeline";
 export type { ActivityTimelineProps } from "./ActivityTimeline";
 export { GroupMapView } from "./GroupMapView";
 export type { GroupMapViewProps, MembershipItem } from "./GroupMapView";
+export { Leaderboard } from "./Leaderboard";
+export type { LeaderboardProps } from "./Leaderboard";
 export { CreateGroupView } from "./CreateGroupView";
 export { Header, HeaderView } from "./Header";
 export type { HeaderUser } from "./Header";

--- a/supabase/migrations/20260301130000_create_leaderboard_rpc.sql
+++ b/supabase/migrations/20260301130000_create_leaderboard_rpc.sql
@@ -1,0 +1,29 @@
+-- グループ内のユーザーごとの獲得タイル数ランキングを返す RPC。
+-- 集計は DB 側で行い、パフォーマンスを確保する。
+-- 戻り値: user_id, display_name, icon_url, tile_count（降順）
+
+CREATE OR REPLACE FUNCTION get_group_leaderboard(target_group_id UUID)
+RETURNS TABLE (
+    user_id     UUID,
+    display_name TEXT,
+    icon_url    TEXT,
+    tile_count  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT
+    u.id         AS user_id,
+    u.display_name,
+    u.icon_url,
+    COUNT(t.h3_index)::BIGINT AS tile_count
+  FROM tiles t
+  INNER JOIN users u ON u.id = t.owner_id
+  WHERE t.group_id = target_group_id
+  GROUP BY u.id, u.display_name, u.icon_url
+  ORDER BY tile_count DESC;
+$$;
+
+COMMENT ON FUNCTION get_group_leaderboard(UUID) IS
+  '指定グループ内のユーザーごとの獲得タイル数を降順で返す。リーダーボード用。';


### PR DESCRIPTION
## 概要 (Context)

指定したグループ内での「ユーザーごとの獲得タイル数ランキング（リーダーボード）」を実装する。集計はデータベース側の RPC で行い、パフォーマンスを確保している。

## 対応背景

- グループメンバー間の競争を可視化し、陣取りのモチベーションを高めるため。
- 集計を DB 側で行うことで、アプリケーション層の負荷を抑えつつ一貫したランキングを返すため。

## 変更内容 (Changes)

- **Supabase**: `get_group_leaderboard(target_group_id UUID)` RPC を新規追加。`tiles` を `owner_id` で GROUP BY し、`users` と JOIN してタイル数降順で返す。
- **API**: `GET /api/groups/[id]/leaderboard` を追加。グループメンバーである場合のみ RPC を呼び出し、結果を JSON で返却。
- **フロントエンド**: `Leaderboard` organism を新規作成。選択中グループのランキングを取得し、順位・アイコン・名前・獲得タイル数を表示。1〜3位に王冠アイコン（lucide-react）で装飾。
- **レイアウト**: 地図画面の右側パネルにリーダーボードを配置。既存の Activity Log と同一パネル内に統合（`ActivityTimeline` に `embedded` オプションを追加）。
- **Storybook**: `Leaderboard.stories.tsx` を追加し、モックデータでのプレビューを可能にした。

## 動作確認手順 (How to Test)

1. ローカルで `supabase db reset` または `supabase migration up` を実行し、マイグレーション `20260301130000_create_leaderboard_rpc.sql` を適用する。
2. ログインし、グループを選択した状態でメイン画面を開く。右パネル上部に「ランキング」が表示されることを確認する。
3. ランキングがタイル数降順で表示されること、1〜3位に王冠アイコンが付くことを確認する。タイルが0件のグループでは「まだタイルがありません」と表示されることを確認する。
4. （任意）Storybook で `Organisms/Leaderboard` の `WithMockEntries` を開き、見た目を確認する。

## 影響範囲と懸念事項 (Impact & Concerns)

- `ActivityTimeline` に `embedded` プロップを追加したため、既存で `embedded` を渡していない呼び出しは従来どおり単体の aside として表示される（後方互換あり）。
- RPC は `SECURITY INVOKER` のため、API Route が service role で呼ぶ場合は RLS をバイパスする。認可は API Route 側でグループメンバーであることを確認しており問題なし。

## チェックリスト (Checklist)

- [ ] 必要なテストコードを追加・更新し、すべてパスしている
- [ ] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある
- [ ] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている
