### PR TITLE
ユーザーごとにタイルカラーを変更

### DIFF
--- a/client/components/organisms/Map.tsx
+++ b/client/components/organisms/Map.tsx
@@ -42,20 +42,6 @@ const FILL_OPACITY_BY_SCORE: DataDrivenPropertyValueSpecification<number> = [
   0.4,
 ];
 
-/**
- * スコア（0–100）に応じた fill-color。
- * 0→薄い緑、100→濃い緑を均等に傾斜。最大は #15803d で抑える。
- */
-const FILL_COLOR_BY_SCORE: DataDrivenPropertyValueSpecification<string> = [
-  "interpolate",
-  ["linear"],
-  SCORE_AS_NUMBER,
-  0,
-  "#bbf7d0",   // 薄い緑
-  100,
-  "#15803d",    // 濃い緑（最大）
-];
-
 /** 東京都新宿区周辺の初期表示（経度・緯度・ズーム） */
 const INITIAL_VIEW_STATE = {
   longitude: 139.6917,
@@ -225,7 +211,7 @@ export function Map({ groupId, initialTiles }: MapProps = {}) {
           type="fill"
           source="h3-hex-source"
           paint={{
-            "fill-color": FILL_COLOR_BY_SCORE,
+            "fill-color": ["get", "color"],
             "fill-opacity": FILL_OPACITY_BY_SCORE,
           }}
         />
@@ -234,7 +220,7 @@ export function Map({ groupId, initialTiles }: MapProps = {}) {
           type="line"
           source="h3-hex-source"
           paint={{
-            "line-color": "#15803d",
+            "line-color": ["get", "color"],
             "line-width": 1.5,
           }}
         />

--- a/client/lib/color-utils.ts
+++ b/client/lib/color-utils.ts
@@ -1,0 +1,46 @@
+/**
+ * 文字列から一意のHEXカラーを生成するユーティリティ。
+ * 地図上のH3タイルのユーザー（owner_id）識別用。同じ文字列は常に同じ色を返す。
+ */
+
+/**
+ * 文字列をハッシュして 0 以上 max 未満の整数を返す（djb2 風）。
+ */
+function hashString(str: string, max: number): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 33 + str.charCodeAt(i)) >>> 0;
+  }
+  return Math.abs(hash) % max;
+}
+
+/**
+ * HSL (H: 0-360, S/L: 0-100) を #RRGGBB に変換する。
+ */
+function hslToHex(h: number, s: number, l: number): string {
+  s /= 100;
+  l /= 100;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12;
+    return l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
+  };
+  const r = Math.round(255 * Math.max(0, Math.min(1, f(0))));
+  const g = Math.round(255 * Math.max(0, Math.min(1, f(8))));
+  const b = Math.round(255 * Math.max(0, Math.min(1, f(4))));
+  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+}
+
+/**
+ * 文字列（例: owner_id の UUID）から、常に同じ一意のHEXカラーコードを返す。
+ * 地図上で視認しやすいよう、彩度・明度を一定範囲に抑えた色を生成する。
+ *
+ * @param str - 入力文字列（UUID など）
+ * @returns #RRGGBB 形式のHEXカラーコード
+ */
+export function stringToColor(str: string): string {
+  const hue = hashString(str, 360);
+  const saturation = 65 + (hashString(str + "s", 16)); // 65–80%
+  const lightness = 42 + (hashString(str + "l", 18));  // 42–59%
+  return hslToHex(hue, saturation, lightness);
+}

--- a/client/lib/h3-geojson.ts
+++ b/client/lib/h3-geojson.ts
@@ -5,6 +5,7 @@
  * @see https://h3geo.org/docs/api/indexing
  */
 import { cellsToMultiPolygon, isValidCell } from "h3-js";
+import { stringToColor } from "./color-utils";
 
 /** GeoJSON Feature（Geometry は MultiPolygon） */
 export interface H3GeoJSONFeature {
@@ -73,11 +74,13 @@ export interface TileRecord {
   group_id: string;
 }
 
-/** タイル用 GeoJSON Feature の properties（地図の fill-opacity などで参照） */
+/** タイル用 GeoJSON Feature の properties（地図の fill-opacity / fill-color などで参照） */
 export interface TileFeatureProperties {
   score: number;
   owner_id: string;
   group_id: string;
+  /** ユーザー（owner_id）識別用の固有HEXカラー */
+  color: string;
 }
 
 /**
@@ -135,6 +138,7 @@ export function tilesToGeoJSONFeatureCollection(
             score: tile.score,
             owner_id: tile.owner_id,
             group_id: tile.group_id,
+            color: stringToColor(tile.owner_id),
           } as TileFeatureProperties & Record<string, unknown>,
         };
       })


### PR DESCRIPTION
## 概要 (Context)

地図上のH3タイルを、単一の緑色ではなく「ユーザー（owner_id）ごとの固有カラー」で表示するように変更する。

## 対応背景

- 現状は全タイルが緑系の単色で、オーナー識別がしづらい。
- スコアによる透明度（fill-opacity）の表現はそのまま維持しつつ、塗り色（fill-color）とアウトライン（line-color）をユーザーごとの一意の色に変更する。

## 変更内容 (Changes)

- **client/lib/color-utils.ts**（新規）: 文字列（UUID等）から常に同じHEXカラーを返す `stringToColor(str)` を実装。ハッシュ＋HSLで彩度・明度を調整し地図上で視認しやすい色を生成。
- **client/lib/h3-geojson.ts**: GeoJSON の各 Feature の `properties` に `color`（`stringToColor(tile.owner_id)`）を追加。`TileFeatureProperties` に `color` を追加。
- **client/components/organisms/Map.tsx**:
  - `h3-hex-fill` の `fill-color` を `["get", "color"]` に変更（透明度 `FILL_OPACITY_BY_SCORE` は変更なし）。
  - `h3-hex-outline` の `line-color` を `["get", "color"]` に変更。
  - スコアベースの単色定義（`FILL_COLOR_BY_SCORE`）を削除。

## 動作確認手順 (How to Test)

1. 複数ユーザーがタイルを取得しているグループでマップを表示する。
2. **異なるユーザーのタイルが別々の色で表示されること**を確認する。
3. **透明度のスコア反映は維持されていること**（スコアが高いタイルは濃く、低いタイルは薄く表示される）を確認する。
4. 同一ユーザーのタイルは同じ色で、他ユーザーと区別できることを確認する。

## 影響範囲と懸念事項 (Impact & Concerns)

- フロントエンドの地図描画のみ。API・DB・バッチは変更なし。
- 色の衝突（似た色になるユーザー）はハッシュの性質上あり得るが、彩度・明度を一定範囲にしているため概ね識別可能。

## チェックリスト (Checklist)

- [ ] 必要なテストコードを追加・更新し、すべてパスしている
- [ ] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある
- [ ] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている
