### PR TITLE
タイルにアイコンを追加

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -4,3 +4,4 @@
 node_modules/
 .next/
 storybook-static/
+tsconfig.tsbuildinfo

--- a/client/app/api/groups/[id]/tiles/route.ts
+++ b/client/app/api/groups/[id]/tiles/route.ts
@@ -50,9 +50,9 @@ export async function GET(_request: Request, { params }: RouteParams) {
     );
   }
 
-  const { data: tiles, error: tilesError } = await supabase
+  const { data: tilesRaw, error: tilesError } = await supabase
     .from("tiles")
-    .select("h3_index, owner_id, score, group_id")
+    .select("h3_index, owner_id, score, group_id, users!owner_id(icon_url)")
     .eq("group_id", groupId);
 
   if (tilesError) {
@@ -67,5 +67,30 @@ export async function GET(_request: Request, { params }: RouteParams) {
     );
   }
 
-  return NextResponse.json(tiles ?? []);
+  const tiles = (tilesRaw ?? []).map(
+    (row: {
+      h3_index: string;
+      owner_id: string;
+      score: number;
+      group_id: string;
+      users?: { icon_url: string | null } | { icon_url: string | null }[] | null;
+    }) => {
+      const users = row.users;
+      const iconUrl =
+        users == null
+          ? null
+          : Array.isArray(users)
+            ? users[0]?.icon_url ?? null
+            : users.icon_url ?? null;
+      return {
+        h3_index: row.h3_index,
+        owner_id: row.owner_id,
+        score: row.score,
+        group_id: row.group_id,
+        icon_url: iconUrl,
+      };
+    }
+  );
+
+  return NextResponse.json(tiles);
 }

--- a/client/app/api/proxy-image/route.ts
+++ b/client/app/api/proxy-image/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * GET /api/proxy-image?url=...
+ * 外部画像URL（Strava CDN等）をサーバー側で取得し、同一オリジンとして返す。
+ * ブラウザの map.loadImage() は fetch を使うため CORS でブロックされるため、
+ * このプロキシ経由で取得することで CORS を回避する。
+ *
+ * 許可するURL: HTTPS かつ Strava 系 CDN（*.cloudfront.net の /pictures/ を含むパス）に限定。
+ */
+const ALLOWED_HOST_PATTERN = /^https:\/\/([a-z0-9-]+\.)*cloudfront\.net\//i;
+const ALLOWED_PATH_PATTERN = /\/pictures\//i;
+
+function isAllowedUrl(urlStr: string): boolean {
+  try {
+    const url = new URL(urlStr);
+    if (url.protocol !== "https:") return false;
+    const fullUrl = url.toString();
+    return ALLOWED_HOST_PATTERN.test(fullUrl) && ALLOWED_PATH_PATTERN.test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const urlParam = request.nextUrl.searchParams.get("url");
+  if (!urlParam || typeof urlParam !== "string") {
+    return NextResponse.json(
+      { error: "Bad Request", message: "url クエリが必要です" },
+      { status: 400 }
+    );
+  }
+
+  if (!isAllowedUrl(urlParam)) {
+    return NextResponse.json(
+      { error: "Forbidden", message: "許可されていない画像URLです" },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const res = await fetch(urlParam, {
+      headers: {
+        "User-Agent": "StravaHexTurf/1.0 (Image Proxy)",
+      },
+      next: { revalidate: 3600 },
+    });
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: "Upstream Error", message: "画像の取得に失敗しました" },
+        { status: 502 }
+      );
+    }
+
+    const contentType = res.headers.get("content-type") ?? "image/jpeg";
+    const buffer = await res.arrayBuffer();
+
+    return new NextResponse(buffer, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=3600, s-maxage=3600",
+      },
+    });
+  } catch (e) {
+    console.error("proxy-image fetch error:", e);
+    return NextResponse.json(
+      { error: "Internal Server Error", message: "画像の取得に失敗しました" },
+      { status: 502 }
+    );
+  }
+}

--- a/client/app/api/tiles/route.ts
+++ b/client/app/api/tiles/route.ts
@@ -36,9 +36,9 @@ export async function GET() {
     return NextResponse.json([]);
   }
 
-  const { data: tiles, error: tilesError } = await supabase
+  const { data: tilesRaw, error: tilesError } = await supabase
     .from("tiles")
-    .select("h3_index, owner_id, score, group_id")
+    .select("h3_index, owner_id, score, group_id, users!owner_id(icon_url)")
     .in("group_id", groupIds);
 
   if (tilesError) {
@@ -53,5 +53,30 @@ export async function GET() {
     );
   }
 
-  return NextResponse.json(tiles ?? []);
+  const tiles = (tilesRaw ?? []).map(
+    (row: {
+      h3_index: string;
+      owner_id: string;
+      score: number;
+      group_id: string;
+      users?: { icon_url: string | null } | { icon_url: string | null }[] | null;
+    }) => {
+      const users = row.users;
+      const iconUrl =
+        users == null
+          ? null
+          : Array.isArray(users)
+            ? users[0]?.icon_url ?? null
+            : users.icon_url ?? null;
+      return {
+        h3_index: row.h3_index,
+        owner_id: row.owner_id,
+        score: row.score,
+        group_id: row.group_id,
+        icon_url: iconUrl,
+      };
+    }
+  );
+
+  return NextResponse.json(tiles);
 }

--- a/client/app/icon.svg
+++ b/client/app/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#ea580c"
+  stroke-width="2">
+  <circle cx="16" cy="16" r="12" />
+  <path d="M12 16h8M16 12v8" />
+</svg>

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -12,6 +12,7 @@ const notoSansJP = Noto_Sans_JP({
 export const metadata: Metadata = {
   title: "Strava陣取り",
   description: "ランニングルートを陣取りゲームに",
+  icons: { icon: "/icon.svg" },
 };
 
 export default function RootLayout({

--- a/client/components/organisms/Map.tsx
+++ b/client/components/organisms/Map.tsx
@@ -58,29 +58,112 @@ const INITIAL_VIEW_STATE = {
   zoom: 12,
 } as const;
 
-/** デフォルトアイコン用の 32x32 RGBA 画像データ（灰色の円）を生成する。MapLibre の addImage に渡す。 */
+/** アイコン表示サイズ（ピクセル）。丸にクリップした画像の一辺。 */
+const ICON_PX = 48;
+
+/** 縁のグラデーション：上（明るいオレンジ赤）→ 下（濃い赤） */
+const BORDER_TOP = { r: 255, g: 100, b: 60 };
+const BORDER_BOTTOM = { r: 180, g: 40, b: 30 };
+
+function getBorderGradientColor(cy: number, r: number, y: number): { r: number; g: number; b: number } {
+  const t = Math.max(0, Math.min(1, (y - cy + r) / (2 * r)));
+  return {
+    r: Math.round(BORDER_TOP.r + t * (BORDER_BOTTOM.r - BORDER_TOP.r)),
+    g: Math.round(BORDER_TOP.g + t * (BORDER_BOTTOM.g - BORDER_TOP.g)),
+    b: Math.round(BORDER_TOP.b + t * (BORDER_BOTTOM.b - BORDER_TOP.b)),
+  };
+}
+
+/** デフォルトアイコン用の RGBA 画像データ（灰色の円＋グラデーション縁）を生成する。 */
 function createDefaultIconImage(): ImageData {
-  const size = 32;
+  const size = ICON_PX;
   const data = new Uint8ClampedArray(size * size * 4);
   const cx = size / 2;
   const cy = size / 2;
-  const r = (size / 2) - 2;
+  const r = (size / 2) - 1;
+  const borderMin = r - 1.5;
+  const borderMax = r + 1.5;
   for (let y = 0; y < size; y++) {
     for (let x = 0; x < size; x++) {
       const dx = x - cx;
       const dy = y - cy;
+      const d = Math.sqrt(dx * dx + dy * dy);
       const i = (y * size + x) * 4;
-      if (dx * dx + dy * dy <= r * r) {
-        data[i] = 120;     // R
-        data[i + 1] = 120; // G
-        data[i + 2] = 120; // B
-        data[i + 3] = 255; // A
+      if (d <= borderMin) {
+        data[i] = 120;
+        data[i + 1] = 120;
+        data[i + 2] = 120;
+        data[i + 3] = 255;
+      } else if (d <= borderMax) {
+        const c = getBorderGradientColor(cy, r, y);
+        data[i] = c.r;
+        data[i + 1] = c.g;
+        data[i + 2] = c.b;
+        data[i + 3] = 255;
       } else {
         data[i + 3] = 0;
       }
     }
   }
   return new ImageData(data, size, size);
+}
+
+/**
+ * 画像を円形にクリップした ImageData を生成する。ピクセル単位で円の外側を透明にし、縁をオレンジ→赤のグラデーションで縁取る。
+ */
+function createCircularIconImage(
+  source: HTMLImageElement | ImageBitmap,
+  size: number = ICON_PX
+): ImageData {
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+  if (!ctx) return new ImageData(size, size);
+  ctx.drawImage(source, 0, 0, size, size);
+  const src = ctx.getImageData(0, 0, size, size);
+  const out = new ImageData(size, size);
+  const cx = size / 2;
+  const cy = size / 2;
+  const r = size / 2 - 0.5;
+  const borderMin = r - 1.5;
+  const borderMax = r + 1.5;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const dx = x - cx;
+      const dy = y - cy;
+      const d = Math.sqrt(dx * dx + dy * dy);
+      const si = (y * size + x) * 4;
+      const oi = si;
+      if (d <= borderMin) {
+        out.data[oi] = src.data[si];
+        out.data[oi + 1] = src.data[si + 1];
+        out.data[oi + 2] = src.data[si + 2];
+        out.data[oi + 3] = src.data[si + 3];
+      } else if (d <= borderMax) {
+        const c = getBorderGradientColor(cy, r, y);
+        out.data[oi] = c.r;
+        out.data[oi + 1] = c.g;
+        out.data[oi + 2] = c.b;
+        out.data[oi + 3] = 255;
+      } else {
+        out.data[oi] = 0;
+        out.data[oi + 1] = 0;
+        out.data[oi + 2] = 0;
+        out.data[oi + 3] = 0;
+      }
+    }
+  }
+  return out;
+}
+
+/** MapLibre の addImage に渡す形式に変換する（一部環境で ImageData の透明が効かないため）。 */
+function toStyleImage(imageData: ImageData): { width: number; height: number; data: Uint8Array } {
+  return {
+    width: imageData.width,
+    height: imageData.height,
+    data: new Uint8Array(imageData.data),
+  };
 }
 
 /** ユーザーアイコンをタイル中心に表示するシンボルレイヤー（minzoom: 12.5）。useMap で map を取得し、styleimagemissing でデフォルトアイコンを登録する。 */
@@ -120,12 +203,18 @@ function TileIconLayer({ tiles }: { tiles: TileRecord[] }) {
     const mapInstance = map;
 
     const onStyleImageMissing = (e: { id: string }) => {
-      if (e.id === DEFAULT_ICON_ID && !mapInstance.hasImage(DEFAULT_ICON_ID)) {
-        try {
-          mapInstance.addImage(DEFAULT_ICON_ID, createDefaultIconImage());
-        } catch {
-          // 無視
+      const id = e.id;
+      if (mapInstance.hasImage(id)) return;
+      try {
+        if (id === DEFAULT_ICON_ID) {
+          mapInstance.addImage(DEFAULT_ICON_ID, toStyleImage(createDefaultIconImage()));
+          return;
         }
+        if (id.startsWith("http://") || id.startsWith("https://")) {
+          mapInstance.addImage(id, toStyleImage(createDefaultIconImage()));
+        }
+      } catch {
+        // 無視
       }
     };
 
@@ -135,7 +224,8 @@ function TileIconLayer({ tiles }: { tiles: TileRecord[] }) {
     if (url) {
       mapInstance.loadImage(url).then((res) => {
         if (!mapInstance.hasImage(DEFAULT_ICON_ID) && res?.data) {
-          mapInstance.addImage(DEFAULT_ICON_ID, res.data);
+          const circular = createCircularIconImage(res.data, ICON_PX);
+          mapInstance.addImage(DEFAULT_ICON_ID, toStyleImage(circular));
         }
       }).catch(() => {
         // 静的ファイル読み込み失敗時は styleimagemissing のプログラム生成に任せる
@@ -163,8 +253,14 @@ function TileIconLayer({ tiles }: { tiles: TileRecord[] }) {
           const response = await mapInstance.loadImage(loadUrl);
           if (cancelled) return;
           const image = response.data;
-          if (image && !mapInstance.hasImage(url)) {
-            mapInstance.addImage(url, image);
+          if (image) {
+            const circular = createCircularIconImage(image, ICON_PX);
+            const styleImg = toStyleImage(circular);
+            if (mapInstance.hasImage(url)) {
+              mapInstance.updateImage(url, styleImg);
+            } else {
+              mapInstance.addImage(url, styleImg);
+            }
           }
           nextLoaded.add(url);
         } catch {
@@ -198,7 +294,7 @@ function TileIconLayer({ tiles }: { tiles: TileRecord[] }) {
       minzoom={12.5}
       layout={{
         "icon-image": ["get", "icon_url"],
-        "icon-size": 0.35,
+        "icon-size": 1,
         "icon-allow-overlap": true,
         "icon-ignore-placement": true,
       }}

--- a/client/components/organisms/Map.tsx
+++ b/client/components/organisms/Map.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Map as MapLibreMap, Source, Layer } from "@vis.gl/react-maplibre";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Map as MapLibreMap, Source, Layer, useMap } from "@vis.gl/react-maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
-import type { DataDrivenPropertyValueSpecification } from "maplibre-gl";
+import type { DataDrivenPropertyValueSpecification, FilterSpecification } from "maplibre-gl";
 import {
   tilesToGeoJSONFeatureCollection,
   type TileRecord,
@@ -48,6 +48,84 @@ const INITIAL_VIEW_STATE = {
   latitude: 35.6896,
   zoom: 12,
 } as const;
+
+/** ユーザーアイコンをタイル中心に表示するシンボルレイヤー（minzoom: 14）。useMap で map を取得し、icon_url を動的登録する。 */
+function TileIconLayer({ tiles }: { tiles: TileRecord[] }) {
+  const maps = useMap();
+  const mapRef = maps?.current;
+  const loadedUrlsRef = useRef<Set<string>>(new Set());
+  const [loadedUrls, setLoadedUrls] = useState<Set<string>>(new Set());
+
+  const uniqueIconUrls = useMemo(() => {
+    const urls = new Set<string>();
+    for (const t of tiles) {
+      if (t.icon_url && t.icon_url.trim()) urls.add(t.icon_url.trim());
+    }
+    return Array.from(urls);
+  }, [tiles]);
+
+  useEffect(() => {
+    const map = mapRef?.getMap?.();
+    if (!map || uniqueIconUrls.length === 0) return;
+
+    const mapInstance = map;
+    let cancelled = false;
+
+    async function loadAndAddImages() {
+      const nextLoaded = new Set(loadedUrlsRef.current);
+      for (const url of uniqueIconUrls) {
+        if (nextLoaded.has(url)) continue;
+        try {
+          const response = await mapInstance.loadImage(url);
+          if (cancelled) return;
+          const image = response.data;
+          if (image && !mapInstance.hasImage(url)) {
+            mapInstance.addImage(url, image);
+          }
+          nextLoaded.add(url);
+        } catch {
+          // 読み込み失敗（CORS等）はスキップ
+        }
+      }
+      if (!cancelled) {
+        loadedUrlsRef.current = nextLoaded;
+        setLoadedUrls(new Set(nextLoaded));
+      }
+    }
+
+    loadAndAddImages();
+    return () => { cancelled = true; };
+  }, [mapRef, uniqueIconUrls]);
+
+  const filter: FilterSpecification | undefined = useMemo(() => {
+    const list = Array.from(loadedUrls);
+    if (list.length === 0) return ["==", ["get", "icon_url"], ""];
+    return [
+      "all",
+      ["has", "icon_url"],
+      ["in", ["get", "icon_url"], ["literal", list]],
+    ] as FilterSpecification;
+  }, [loadedUrls]);
+
+  if (!mapRef) return null;
+
+  return (
+    <Layer
+      id="h3-hex-user-icon"
+      type="symbol"
+      source="h3-hex-source"
+      minzoom={14}
+      layout={{
+        "symbol-placement": "point",
+        "icon-image": ["get", "icon_url"],
+        "icon-size": 0.35,
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true,
+      }}
+      filter={filter}
+    />
+  );
+}
 
 /**
  * ベース地図用スタイル（ラスタータイルのみ）。
@@ -239,6 +317,7 @@ export function Map({ groupId, initialTiles }: MapProps = {}) {
             "text-halo-width": 1.5,
           }}
         />
+        <TileIconLayer tiles={tiles} />
       </MapLibreMap>
     </div>
   );

--- a/client/components/organisms/Map.tsx
+++ b/client/components/organisms/Map.tsx
@@ -6,14 +6,23 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import type { DataDrivenPropertyValueSpecification, FilterSpecification } from "maplibre-gl";
 import {
   tilesToGeoJSONFeatureCollection,
+  tilesToIconPointFeatureCollection,
+  DEFAULT_ICON_ID,
   type TileRecord,
   type H3GeoJSONFeatureCollection,
+  type TileIconPointFeatureCollection,
 } from "@/lib/h3-geojson";
 
 const TILES_POLL_INTERVAL_MS = 15_000;
 
 /** 空の GeoJSON（タイル未取得時・未ログイン時） */
 const EMPTY_GEOJSON: H3GeoJSONFeatureCollection = {
+  type: "FeatureCollection",
+  features: [],
+};
+
+/** 空の Point FeatureCollection（アイコン用ソース） */
+const EMPTY_ICON_POINTS: TileIconPointFeatureCollection = {
   type: "FeatureCollection",
   features: [],
 };
@@ -49,7 +58,32 @@ const INITIAL_VIEW_STATE = {
   zoom: 12,
 } as const;
 
-/** ユーザーアイコンをタイル中心に表示するシンボルレイヤー（minzoom: 14）。useMap で map を取得し、icon_url を動的登録する。 */
+/** デフォルトアイコン用の 32x32 RGBA 画像データ（灰色の円）を生成する。MapLibre の addImage に渡す。 */
+function createDefaultIconImage(): ImageData {
+  const size = 32;
+  const data = new Uint8ClampedArray(size * size * 4);
+  const cx = size / 2;
+  const cy = size / 2;
+  const r = (size / 2) - 2;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const dx = x - cx;
+      const dy = y - cy;
+      const i = (y * size + x) * 4;
+      if (dx * dx + dy * dy <= r * r) {
+        data[i] = 120;     // R
+        data[i + 1] = 120; // G
+        data[i + 2] = 120; // B
+        data[i + 3] = 255; // A
+      } else {
+        data[i + 3] = 0;
+      }
+    }
+  }
+  return new ImageData(data, size, size);
+}
+
+/** ユーザーアイコンをタイル中心に表示するシンボルレイヤー（minzoom: 12.5）。useMap で map を取得し、styleimagemissing でデフォルトアイコンを登録する。 */
 function TileIconLayer({ tiles }: { tiles: TileRecord[] }) {
   const maps = useMap();
   const mapRef = maps?.current;
@@ -59,14 +93,63 @@ function TileIconLayer({ tiles }: { tiles: TileRecord[] }) {
   const uniqueIconUrls = useMemo(() => {
     const urls = new Set<string>();
     for (const t of tiles) {
-      if (t.icon_url && t.icon_url.trim()) urls.add(t.icon_url.trim());
+      if (t.icon_url && t.icon_url.trim() && t.icon_url !== DEFAULT_ICON_ID) {
+        urls.add(t.icon_url.trim());
+      }
     }
     return Array.from(urls);
   }, [tiles]);
 
+  /** 外部オリジンの画像は CORS でブロックされるため、自前プロキシ経由のURLに変換する。 */
+  const getImageLoadUrl = useCallback((url: string): string => {
+    if (typeof window === "undefined") return url;
+    try {
+      const target = new URL(url);
+      const origin = window.location.origin;
+      if (target.origin === origin) return url;
+      return `${origin}/api/proxy-image?url=${encodeURIComponent(url)}`;
+    } catch {
+      return url;
+    }
+  }, []);
+
   useEffect(() => {
     const map = mapRef?.getMap?.();
-    if (!map || uniqueIconUrls.length === 0) return;
+    if (!map) return;
+
+    const mapInstance = map;
+
+    const onStyleImageMissing = (e: { id: string }) => {
+      if (e.id === DEFAULT_ICON_ID && !mapInstance.hasImage(DEFAULT_ICON_ID)) {
+        try {
+          mapInstance.addImage(DEFAULT_ICON_ID, createDefaultIconImage());
+        } catch {
+          // 無視
+        }
+      }
+    };
+
+    mapInstance.on("styleimagemissing", onStyleImageMissing);
+
+    const url = typeof window !== "undefined" ? `${window.location.origin}/default-avatar.svg` : "";
+    if (url) {
+      mapInstance.loadImage(url).then((res) => {
+        if (!mapInstance.hasImage(DEFAULT_ICON_ID) && res?.data) {
+          mapInstance.addImage(DEFAULT_ICON_ID, res.data);
+        }
+      }).catch(() => {
+        // 静的ファイル読み込み失敗時は styleimagemissing のプログラム生成に任せる
+      });
+    }
+
+    return () => {
+      mapInstance.off("styleimagemissing", onStyleImageMissing);
+    };
+  }, [mapRef]);
+
+  useEffect(() => {
+    const map = mapRef?.getMap?.();
+    if (!map) return;
 
     const mapInstance = map;
     let cancelled = false;
@@ -76,7 +159,8 @@ function TileIconLayer({ tiles }: { tiles: TileRecord[] }) {
       for (const url of uniqueIconUrls) {
         if (nextLoaded.has(url)) continue;
         try {
-          const response = await mapInstance.loadImage(url);
+          const loadUrl = getImageLoadUrl(url);
+          const response = await mapInstance.loadImage(loadUrl);
           if (cancelled) return;
           const image = response.data;
           if (image && !mapInstance.hasImage(url)) {
@@ -84,7 +168,7 @@ function TileIconLayer({ tiles }: { tiles: TileRecord[] }) {
           }
           nextLoaded.add(url);
         } catch {
-          // 読み込み失敗（CORS等）はスキップ
+          // 読み込み失敗はスキップ（CORS/プロキシエラー等）
         }
       }
       if (!cancelled) {
@@ -95,11 +179,10 @@ function TileIconLayer({ tiles }: { tiles: TileRecord[] }) {
 
     loadAndAddImages();
     return () => { cancelled = true; };
-  }, [mapRef, uniqueIconUrls]);
+  }, [mapRef, uniqueIconUrls, getImageLoadUrl]);
 
   const filter: FilterSpecification | undefined = useMemo(() => {
-    const list = Array.from(loadedUrls);
-    if (list.length === 0) return ["==", ["get", "icon_url"], ""];
+    const list = [DEFAULT_ICON_ID, ...Array.from(loadedUrls)];
     return [
       "all",
       ["has", "icon_url"],
@@ -107,16 +190,13 @@ function TileIconLayer({ tiles }: { tiles: TileRecord[] }) {
     ] as FilterSpecification;
   }, [loadedUrls]);
 
-  if (!mapRef) return null;
-
   return (
     <Layer
       id="h3-hex-user-icon"
       type="symbol"
-      source="h3-hex-source"
-      minzoom={14}
+      source="h3-hex-icon-source"
+      minzoom={12.5}
       layout={{
-        "symbol-placement": "point",
         "icon-image": ["get", "icon_url"],
         "icon-size": 0.35,
         "icon-allow-overlap": true,
@@ -267,6 +347,11 @@ export function Map({ groupId, initialTiles }: MapProps = {}) {
     return tilesToGeoJSONFeatureCollection(tiles);
   }, [tiles]);
 
+  const iconPointData = useMemo(() => {
+    if (tiles.length === 0) return EMPTY_ICON_POINTS;
+    return tilesToIconPointFeatureCollection(tiles);
+  }, [tiles]);
+
   return (
     <div className="absolute inset-0">
       {fetchError && (
@@ -283,6 +368,11 @@ export function Map({ groupId, initialTiles }: MapProps = {}) {
           id="h3-hex-source"
           type="geojson"
           data={geojsonData}
+        />
+        <Source
+          id="h3-hex-icon-source"
+          type="geojson"
+          data={iconPointData}
         />
         <Layer
           id="h3-hex-fill"

--- a/client/lib/h3-geojson.ts
+++ b/client/lib/h3-geojson.ts
@@ -66,12 +66,13 @@ export function h3IndexesToGeoJSONFeatureCollection(
   }
 }
 
-/** API から取得するタイル1件の型（h3_index, owner_id, score, group_id） */
+/** API から取得するタイル1件の型（h3_index, owner_id, score, group_id, icon_url） */
 export interface TileRecord {
   h3_index: string;
   owner_id: string;
   score: number;
   group_id: string;
+  icon_url?: string | null;
 }
 
 /** タイル用 GeoJSON Feature の properties（地図の fill-opacity / fill-color などで参照） */
@@ -81,6 +82,8 @@ export interface TileFeatureProperties {
   group_id: string;
   /** ユーザー（owner_id）識別用の固有HEXカラー */
   color: string;
+  /** 所有者のアバター画像URL（ズーム時シンボル表示用） */
+  icon_url?: string | null;
 }
 
 /**
@@ -139,6 +142,7 @@ export function tilesToGeoJSONFeatureCollection(
             owner_id: tile.owner_id,
             group_id: tile.group_id,
             color: stringToColor(tile.owner_id),
+            icon_url: tile.icon_url ?? null,
           } as TileFeatureProperties & Record<string, unknown>,
         };
       })

--- a/client/lib/h3-geojson.ts
+++ b/client/lib/h3-geojson.ts
@@ -4,7 +4,7 @@
  * @see https://www.npmjs.com/package/h3-js
  * @see https://h3geo.org/docs/api/indexing
  */
-import { cellsToMultiPolygon, isValidCell } from "h3-js";
+import { cellsToMultiPolygon, cellToLatLng, isValidCell } from "h3-js";
 import { stringToColor } from "./color-utils";
 
 /** GeoJSON Feature（Geometry は MultiPolygon） */
@@ -155,4 +155,58 @@ export function tilesToGeoJSONFeatureCollection(
   } catch {
     return { type: "FeatureCollection", features: [] };
   }
+}
+
+/** アイコン表示用の Point Feature の properties（icon_url は URL またはデフォルトアイコンID） */
+export interface TileIconPointProperties {
+  icon_url: string;
+}
+
+/** デフォルトアイコン（プロフィール未設定時）の MapLibre 画像ID */
+export const DEFAULT_ICON_ID = "default-avatar";
+
+/** GeoJSON Point FeatureCollection（タイル中心のポイント。全タイルを含め、icon_url がない場合は DEFAULT_ICON_ID を使用） */
+export interface TileIconPointFeatureCollection {
+  type: "FeatureCollection";
+  features: Array<{
+    type: "Feature";
+    geometry: GeoJSON.Point;
+    properties: TileIconPointProperties;
+  }>;
+}
+
+/**
+ * タイルの中心座標を Point FeatureCollection で返す。
+ * 全タイルを含め、icon_url が無い場合は DEFAULT_ICON_ID を指定してデフォルトアイコンを表示する。
+ * cellToLatLng は [lat, lng] を返すため、GeoJSON の [lng, lat] に変換する。
+ */
+export function tilesToIconPointFeatureCollection(
+  tiles: TileRecord[]
+): TileIconPointFeatureCollection {
+  const features: Array<{
+    type: "Feature";
+    geometry: GeoJSON.Point;
+    properties: TileIconPointProperties;
+  }> = [];
+  for (const t of tiles) {
+    if (!t || typeof t.h3_index !== "string" || !t.h3_index || !isValidCell(t.h3_index)) continue;
+    const iconUrl =
+      t.icon_url && typeof t.icon_url === "string" && t.icon_url.trim()
+        ? t.icon_url.trim()
+        : DEFAULT_ICON_ID;
+    try {
+      const [lat, lng] = cellToLatLng(t.h3_index);
+      features.push({
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [lng, lat],
+        },
+        properties: { icon_url: iconUrl },
+      });
+    } catch {
+      // 無効なセルはスキップ
+    }
+  }
+  return { type: "FeatureCollection", features };
 }

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async rewrites() {
+    return [{ source: "/favicon.ico", destination: "/icon.svg" }];
+  },
+};
 
 module.exports = nextConfig;

--- a/client/public/default-avatar.svg
+++ b/client/public/default-avatar.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#787878" />
+</svg>


### PR DESCRIPTION
## 概要 (Context)

地図を一定以上ズームした際（minzoom: 14）に、各H3タイルの中心にその所有者のプロフィール画像（アイコン）を表示する機能を追加する。

## 対応背景

- ユーザーごとの固有カラーとスコアによる透明度という既存の地図表現は維持したまま、ズームイン時に「誰の陣地か」をアイコンで直感的に判別できるようにするため。

## 変更内容 (Changes)

- **タイルAPI拡張**: `GET /api/tiles` および `GET /api/groups/[id]/tiles` で、`tiles` を `users` と JOIN し、`icon_url` を取得してレスポンスに含めるようにした。
- **型・GeoJSON**: `TileRecord` に `icon_url?: string | null` を追加。`tilesToGeoJSONFeatureCollection` で各 Feature の `properties` に `icon_url` を含めるようにした。
- **Map.tsx**: `useMap` で MapLibre インスタンスを取得し、タイル更新ごとに未登録の `icon_url` を `map.loadImage()` / `map.addImage()` で動的登録する `TileIconLayer` を追加。`minzoom: 14` の symbol レイヤーでタイル中心にアイコンを表示（`symbol-placement: "point"`）。既存の `h3-hex-fill` と `h3-hex-outline` は変更していない。

## 動作確認手順 (How to Test)

1. ログインし、グループにタイルが存在する状態で地図画面を開く。
2. ズームレベル14未満では、これまで通りヘックスと枠線・スコアラベルのみ表示され、アイコンは表示されないこと。
3. **ズームレベル14以上に拡大した時にタイルの中央にアイコンが表示されること。**
4. アイコンがない（`icon_url` が null の）所有者のタイルではアイコンは表示されず、他は崩れないこと。

## 影響範囲と懸念事項 (Impact & Concerns)

- アイコン画像は外部URL（Strava アバター等）をそのまま `loadImage` しているため、CORS が許可されていないドメインの場合は読み込み失敗となり、当該タイルではアイコンが表示されない（エラーは握りつぶし、他タイルには影響しない）。
- 既存の地図レイヤー（fill / outline）は一切変更していない。

## チェックリスト (Checklist)

- [ ] 必要なテストコードを追加・更新し、すべてパスしている
- [ ] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある
- [ ] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている