### PR TITLE
アイコンホバーポップを追加

### DIFF
--- a/client/app/api/groups/[id]/tiles/route.ts
+++ b/client/app/api/groups/[id]/tiles/route.ts
@@ -52,7 +52,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
 
   const { data: tilesRaw, error: tilesError } = await supabase
     .from("tiles")
-    .select("h3_index, owner_id, score, group_id, users!owner_id(icon_url)")
+    .select("h3_index, owner_id, score, group_id, last_updated_at, users!owner_id(icon_url, display_name)")
     .eq("group_id", groupId);
 
   if (tilesError) {
@@ -73,7 +73,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
       owner_id: string;
       score: number;
       group_id: string;
-      users?: { icon_url: string | null } | { icon_url: string | null }[] | null;
+      last_updated_at?: string | null;
+      users?: { icon_url: string | null; display_name?: string | null } | { icon_url: string | null; display_name?: string | null }[] | null;
     }) => {
       const users = row.users;
       const iconUrl =
@@ -82,12 +83,20 @@ export async function GET(_request: Request, { params }: RouteParams) {
           : Array.isArray(users)
             ? users[0]?.icon_url ?? null
             : users.icon_url ?? null;
+      const displayName =
+        users == null
+          ? null
+          : Array.isArray(users)
+            ? users[0]?.display_name ?? null
+            : users.display_name ?? null;
       return {
         h3_index: row.h3_index,
         owner_id: row.owner_id,
         score: row.score,
         group_id: row.group_id,
         icon_url: iconUrl,
+        display_name: displayName ?? undefined,
+        last_updated_at: row.last_updated_at ?? undefined,
       };
     }
   );

--- a/client/app/api/tiles/route.ts
+++ b/client/app/api/tiles/route.ts
@@ -38,7 +38,7 @@ export async function GET() {
 
   const { data: tilesRaw, error: tilesError } = await supabase
     .from("tiles")
-    .select("h3_index, owner_id, score, group_id, users!owner_id(icon_url)")
+    .select("h3_index, owner_id, score, group_id, last_updated_at, users!owner_id(icon_url, display_name)")
     .in("group_id", groupIds);
 
   if (tilesError) {
@@ -59,7 +59,8 @@ export async function GET() {
       owner_id: string;
       score: number;
       group_id: string;
-      users?: { icon_url: string | null } | { icon_url: string | null }[] | null;
+      last_updated_at?: string | null;
+      users?: { icon_url: string | null; display_name?: string | null } | { icon_url: string | null; display_name?: string | null }[] | null;
     }) => {
       const users = row.users;
       const iconUrl =
@@ -68,12 +69,20 @@ export async function GET() {
           : Array.isArray(users)
             ? users[0]?.icon_url ?? null
             : users.icon_url ?? null;
+      const displayName =
+        users == null
+          ? null
+          : Array.isArray(users)
+            ? users[0]?.display_name ?? null
+            : users.display_name ?? null;
       return {
         h3_index: row.h3_index,
         owner_id: row.owner_id,
         score: row.score,
         group_id: row.group_id,
         icon_url: iconUrl,
+        display_name: displayName ?? undefined,
+        last_updated_at: row.last_updated_at ?? undefined,
       };
     }
   );

--- a/client/components/organisms/Map.tsx
+++ b/client/components/organisms/Map.tsx
@@ -68,10 +68,12 @@ const HOVERABLE_LAYER_IDS = ["h3-hex-fill", "h3-hex-user-icon"] as const;
 
 /** ホバー/タップ時に表示する陣地情報 */
 interface HoverInfo {
+  /** Popup を表示する固定位置（タイル中心。カーソルは追わない） */
   lngLat: { lng: number; lat: number };
   display_name: string | null;
   last_updated_at: string | null;
   icon_url: string | null;
+  score: number | null;
 }
 
 /** last_updated_at（ISO 文字列）を「取得/防衛: YYYY/MM/DD HH:mm」形式にフォーマット */
@@ -89,6 +91,23 @@ function formatCaptureDate(isoString: string | null | undefined): string {
   } catch {
     return "—";
   }
+}
+
+/** Feature から Popup の固定表示位置（タイル中心）を取得。カーソル位置は使わない。 */
+function getPopupLngLat(
+  feature: MapGeoJSONFeature,
+  properties: Record<string, unknown>
+): { lng: number; lat: number } | null {
+  if (feature.layer?.id === "h3-hex-fill") {
+    const lng = properties.longitude;
+    const lat = properties.latitude;
+    if (typeof lng === "number" && typeof lat === "number") return { lng, lat };
+  }
+  if (feature.layer?.id === "h3-hex-user-icon" && feature.geometry?.type === "Point") {
+    const coords = feature.geometry.coordinates;
+    if (Array.isArray(coords) && coords.length >= 2) return { lng: coords[0], lat: coords[1] };
+  }
+  return null;
 }
 
 /** 縁のグラデーション：上（明るいオレンジ赤）→ 下（濃い赤） */
@@ -388,24 +407,21 @@ export function Map({ groupId, initialTiles }: MapProps = {}) {
     );
     if (hit?.properties) {
       const p = hit.properties as Record<string, unknown>;
-      setHoverInfo({
-        lngLat: { lng: e.lngLat.lng, lat: e.lngLat.lat },
-        display_name: (p.display_name as string | null) ?? null,
-        last_updated_at: (p.last_updated_at as string | null) ?? null,
-        icon_url: (p.icon_url as string | null) ?? null,
-      });
+      const fixedLngLat = getPopupLngLat(hit, p);
+      if (fixedLngLat) {
+        setHoverInfo({
+          lngLat: fixedLngLat,
+          display_name: (p.display_name as string | null) ?? null,
+          last_updated_at: (p.last_updated_at as string | null) ?? null,
+          icon_url: (p.icon_url as string | null) ?? null,
+          score: typeof p.score === "number" ? p.score : (p.score != null ? Number(p.score) : null),
+        });
+      }
       map.getCanvas().style.cursor = "pointer";
     } else {
       setHoverInfo(null);
       map.getCanvas().style.cursor = "";
     }
-  }, []);
-
-  /** マウスが地図外に出たとき: hoverInfo をクリアしカーソルを戻す */
-  const handleMapMouseLeave = useCallback((e: MapLayerMouseEvent) => {
-    setHoverInfo(null);
-    const map = "getMap" in e.target && typeof e.target.getMap === "function" ? e.target.getMap() : e.target;
-    map.getCanvas().style.cursor = "";
   }, []);
 
   /** クリック/タップ: 対象レイヤー上なら Popup 表示（スマホでタップ時に表示するため） */
@@ -418,13 +434,24 @@ export function Map({ groupId, initialTiles }: MapProps = {}) {
     );
     if (hit?.properties) {
       const p = hit.properties as Record<string, unknown>;
-      setHoverInfo({
-        lngLat: { lng: e.lngLat.lng, lat: e.lngLat.lat },
-        display_name: (p.display_name as string | null) ?? null,
-        last_updated_at: (p.last_updated_at as string | null) ?? null,
-        icon_url: (p.icon_url as string | null) ?? null,
-      });
+      const fixedLngLat = getPopupLngLat(hit, p);
+      if (fixedLngLat) {
+        setHoverInfo({
+          lngLat: fixedLngLat,
+          display_name: (p.display_name as string | null) ?? null,
+          last_updated_at: (p.last_updated_at as string | null) ?? null,
+          icon_url: (p.icon_url as string | null) ?? null,
+          score: typeof p.score === "number" ? p.score : (p.score != null ? Number(p.score) : null),
+        });
+      }
     }
+  }, []);
+
+  /** マウスが地図外に出たとき: hoverInfo をクリアしカーソルを戻す */
+  const handleMapMouseLeave = useCallback((e: MapLayerMouseEvent) => {
+    setHoverInfo(null);
+    const map = "getMap" in e.target && typeof e.target.getMap === "function" ? e.target.getMap() : e.target;
+    map.getCanvas().style.cursor = "";
   }, []);
 
   const refetchTiles = useCallback(async () => {
@@ -572,21 +599,6 @@ export function Map({ groupId, initialTiles }: MapProps = {}) {
             "line-width": 1.5,
           }}
         />
-        <Layer
-          id="h3-hex-score-label"
-          type="symbol"
-          source="h3-hex-source"
-          layout={{
-            "text-field": ["to-string", ["get", "score"]],
-            "text-size": 11,
-            "text-anchor": "center",
-          }}
-          paint={{
-            "text-color": "#052e16",
-            "text-halo-color": "#ffffff",
-            "text-halo-width": 1.5,
-          }}
-        />
         <TileIconLayer tiles={tiles} />
         {hoverInfo && (
           <Popup
@@ -613,6 +625,9 @@ export function Map({ groupId, initialTiles }: MapProps = {}) {
                 </span>
                 <span className="text-xs text-gray-500">
                   取得/防衛: {formatCaptureDate(hoverInfo.last_updated_at)}
+                </span>
+                <span className="text-xs text-gray-500">
+                  スコア: {hoverInfo.score != null ? hoverInfo.score : "—"}
                 </span>
               </div>
             </div>

--- a/client/components/organisms/Map.tsx
+++ b/client/components/organisms/Map.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Map as MapLibreMap, Source, Layer, useMap } from "@vis.gl/react-maplibre";
+import { Map as MapLibreMap, Source, Layer, useMap, Popup } from "@vis.gl/react-maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { DataDrivenPropertyValueSpecification, FilterSpecification } from "maplibre-gl";
+import type { MapLayerMouseEvent, MapGeoJSONFeature } from "maplibre-gl";
 import {
   tilesToGeoJSONFeatureCollection,
   tilesToIconPointFeatureCollection,
@@ -12,6 +13,7 @@ import {
   type H3GeoJSONFeatureCollection,
   type TileIconPointFeatureCollection,
 } from "@/lib/h3-geojson";
+import { Avatar } from "@/components/atoms/Avatar";
 
 const TILES_POLL_INTERVAL_MS = 15_000;
 
@@ -60,6 +62,34 @@ const INITIAL_VIEW_STATE = {
 
 /** アイコン表示サイズ（ピクセル）。丸にクリップした画像の一辺。 */
 const ICON_PX = 48;
+
+/** ツールチップの対象レイヤー（ホバー/クリックで Feature を検知するレイヤーID） */
+const HOVERABLE_LAYER_IDS = ["h3-hex-fill", "h3-hex-user-icon"] as const;
+
+/** ホバー/タップ時に表示する陣地情報 */
+interface HoverInfo {
+  lngLat: { lng: number; lat: number };
+  display_name: string | null;
+  last_updated_at: string | null;
+  icon_url: string | null;
+}
+
+/** last_updated_at（ISO 文字列）を「取得/防衛: YYYY/MM/DD HH:mm」形式にフォーマット */
+function formatCaptureDate(isoString: string | null | undefined): string {
+  if (!isoString) return "—";
+  try {
+    const d = new Date(isoString);
+    if (Number.isNaN(d.getTime())) return "—";
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    const h = String(d.getHours()).padStart(2, "0");
+    const min = String(d.getMinutes()).padStart(2, "0");
+    return `${y}/${m}/${day} ${h}:${min}`;
+  } catch {
+    return "—";
+  }
+}
 
 /** 縁のグラデーション：上（明るいオレンジ赤）→ 下（濃い赤） */
 const BORDER_TOP = { r: 255, g: 100, b: 60 };
@@ -345,6 +375,57 @@ export interface MapProps {
 export function Map({ groupId, initialTiles }: MapProps = {}) {
   const [tiles, setTiles] = useState<TileRecord[]>(initialTiles ?? []);
   const [fetchError, setFetchError] = useState<string | null>(null);
+  /** ホバー/タップ中のタイル情報（Popup 表示用）。null のときは非表示 */
+  const [hoverInfo, setHoverInfo] = useState<HoverInfo | null>(null);
+
+  /** マウス移動: 対象レイヤー上の Feature なら hoverInfo を更新しカーソルを pointer に */
+  const handleMapMouseMove = useCallback((e: MapLayerMouseEvent) => {
+    const map = "getMap" in e.target && typeof e.target.getMap === "function" ? e.target.getMap() : e.target;
+    const features = map.queryRenderedFeatures(e.point);
+    const hit = features.find(
+      (f: MapGeoJSONFeature) =>
+        f.layer?.id && (HOVERABLE_LAYER_IDS as readonly string[]).includes(f.layer.id)
+    );
+    if (hit?.properties) {
+      const p = hit.properties as Record<string, unknown>;
+      setHoverInfo({
+        lngLat: { lng: e.lngLat.lng, lat: e.lngLat.lat },
+        display_name: (p.display_name as string | null) ?? null,
+        last_updated_at: (p.last_updated_at as string | null) ?? null,
+        icon_url: (p.icon_url as string | null) ?? null,
+      });
+      map.getCanvas().style.cursor = "pointer";
+    } else {
+      setHoverInfo(null);
+      map.getCanvas().style.cursor = "";
+    }
+  }, []);
+
+  /** マウスが地図外に出たとき: hoverInfo をクリアしカーソルを戻す */
+  const handleMapMouseLeave = useCallback((e: MapLayerMouseEvent) => {
+    setHoverInfo(null);
+    const map = "getMap" in e.target && typeof e.target.getMap === "function" ? e.target.getMap() : e.target;
+    map.getCanvas().style.cursor = "";
+  }, []);
+
+  /** クリック/タップ: 対象レイヤー上なら Popup 表示（スマホでタップ時に表示するため） */
+  const handleMapClick = useCallback((e: MapLayerMouseEvent) => {
+    const map = "getMap" in e.target && typeof e.target.getMap === "function" ? e.target.getMap() : e.target;
+    const features = map.queryRenderedFeatures(e.point);
+    const hit = features.find(
+      (f: MapGeoJSONFeature) =>
+        f.layer?.id && (HOVERABLE_LAYER_IDS as readonly string[]).includes(f.layer.id)
+    );
+    if (hit?.properties) {
+      const p = hit.properties as Record<string, unknown>;
+      setHoverInfo({
+        lngLat: { lng: e.lngLat.lng, lat: e.lngLat.lat },
+        display_name: (p.display_name as string | null) ?? null,
+        last_updated_at: (p.last_updated_at as string | null) ?? null,
+        icon_url: (p.icon_url as string | null) ?? null,
+      });
+    }
+  }, []);
 
   const refetchTiles = useCallback(async () => {
     if (groupId == null && initialTiles === undefined) {
@@ -459,6 +540,9 @@ export function Map({ groupId, initialTiles }: MapProps = {}) {
         initialViewState={INITIAL_VIEW_STATE}
         mapStyle={BASE_MAP_STYLE}
         style={{ width: "100%", height: "100%" }}
+        onMouseMove={handleMapMouseMove}
+        onMouseLeave={handleMapMouseLeave}
+        onClick={handleMapClick}
       >
         <Source
           id="h3-hex-source"
@@ -504,6 +588,36 @@ export function Map({ groupId, initialTiles }: MapProps = {}) {
           }}
         />
         <TileIconLayer tiles={tiles} />
+        {hoverInfo && (
+          <Popup
+            longitude={hoverInfo.lngLat.lng}
+            latitude={hoverInfo.lngLat.lat}
+            anchor="bottom"
+            closeButton={false}
+            closeOnClick={false}
+            className="min-w-[180px] rounded-lg border border-gray-200 bg-white px-3 py-2 shadow-lg"
+          >
+            <div className="flex items-center gap-3">
+              <Avatar
+                src={
+                  hoverInfo.icon_url && hoverInfo.icon_url !== DEFAULT_ICON_ID
+                    ? hoverInfo.icon_url
+                    : "/default-avatar.svg"
+                }
+                alt=""
+                size="md"
+              />
+              <div className="flex flex-col gap-0.5">
+                <span className="font-medium text-gray-900">
+                  {hoverInfo.display_name ?? "—"}
+                </span>
+                <span className="text-xs text-gray-500">
+                  取得/防衛: {formatCaptureDate(hoverInfo.last_updated_at)}
+                </span>
+              </div>
+            </div>
+          </Popup>
+        )}
       </MapLibreMap>
     </div>
   );

--- a/client/lib/h3-geojson.ts
+++ b/client/lib/h3-geojson.ts
@@ -92,6 +92,10 @@ export interface TileFeatureProperties {
   display_name?: string | null;
   /** 最終更新日時 ISO 文字列（ツールチップ表示用） */
   last_updated_at?: string | null;
+  /** タイル中心の経度（Popup の固定表示位置用） */
+  longitude: number;
+  /** タイル中心の緯度（Popup の固定表示位置用） */
+  latitude: number;
 }
 
 /**
@@ -139,6 +143,7 @@ export function tilesToGeoJSONFeatureCollection(
       .map((tile) => {
         const polygon = h3IndexToPolygon.get(tile.h3_index);
         if (!polygon) return null;
+        const [lat, lng] = cellToLatLng(tile.h3_index);
         return {
           type: "Feature" as const,
           geometry: {
@@ -153,6 +158,8 @@ export function tilesToGeoJSONFeatureCollection(
             icon_url: tile.icon_url ?? null,
             display_name: tile.display_name ?? null,
             last_updated_at: tile.last_updated_at ?? null,
+            longitude: lng,
+            latitude: lat,
           } as TileFeatureProperties & Record<string, unknown>,
         };
       })
@@ -174,6 +181,8 @@ export interface TileIconPointProperties {
   display_name?: string | null;
   /** 最終更新日時 ISO 文字列（ツールチップ表示用） */
   last_updated_at?: string | null;
+  /** スコア（ツールチップ表示用） */
+  score?: number | null;
 }
 
 /** デフォルトアイコン（プロフィール未設定時）の MapLibre 画像ID */
@@ -220,6 +229,7 @@ export function tilesToIconPointFeatureCollection(
           icon_url: iconUrl,
           display_name: t.display_name ?? null,
           last_updated_at: t.last_updated_at ?? null,
+          score: t.score ?? null,
         },
       });
     } catch {

--- a/client/lib/h3-geojson.ts
+++ b/client/lib/h3-geojson.ts
@@ -66,13 +66,17 @@ export function h3IndexesToGeoJSONFeatureCollection(
   }
 }
 
-/** API から取得するタイル1件の型（h3_index, owner_id, score, group_id, icon_url） */
+/** API から取得するタイル1件の型（h3_index, owner_id, score, group_id, icon_url, display_name, last_updated_at） */
 export interface TileRecord {
   h3_index: string;
   owner_id: string;
   score: number;
   group_id: string;
   icon_url?: string | null;
+  /** 所有者の表示名（ツールチップ表示用） */
+  display_name?: string | null;
+  /** 最終更新日時 ISO 文字列（取得/防衛日時・ツールチップ表示用） */
+  last_updated_at?: string | null;
 }
 
 /** タイル用 GeoJSON Feature の properties（地図の fill-opacity / fill-color などで参照） */
@@ -84,6 +88,10 @@ export interface TileFeatureProperties {
   color: string;
   /** 所有者のアバター画像URL（ズーム時シンボル表示用） */
   icon_url?: string | null;
+  /** 所有者の表示名（ツールチップ表示用） */
+  display_name?: string | null;
+  /** 最終更新日時 ISO 文字列（ツールチップ表示用） */
+  last_updated_at?: string | null;
 }
 
 /**
@@ -143,6 +151,8 @@ export function tilesToGeoJSONFeatureCollection(
             group_id: tile.group_id,
             color: stringToColor(tile.owner_id),
             icon_url: tile.icon_url ?? null,
+            display_name: tile.display_name ?? null,
+            last_updated_at: tile.last_updated_at ?? null,
           } as TileFeatureProperties & Record<string, unknown>,
         };
       })
@@ -160,6 +170,10 @@ export function tilesToGeoJSONFeatureCollection(
 /** アイコン表示用の Point Feature の properties（icon_url は URL またはデフォルトアイコンID） */
 export interface TileIconPointProperties {
   icon_url: string;
+  /** 所有者の表示名（ツールチップ表示用） */
+  display_name?: string | null;
+  /** 最終更新日時 ISO 文字列（ツールチップ表示用） */
+  last_updated_at?: string | null;
 }
 
 /** デフォルトアイコン（プロフィール未設定時）の MapLibre 画像ID */
@@ -202,7 +216,11 @@ export function tilesToIconPointFeatureCollection(
           type: "Point",
           coordinates: [lng, lat],
         },
-        properties: { icon_url: iconUrl },
+        properties: {
+          icon_url: iconUrl,
+          display_name: t.display_name ?? null,
+          last_updated_at: t.last_updated_at ?? null,
+        },
       });
     } catch {
       // 無効なセルはスキップ


### PR DESCRIPTION
## 概要 (Context)

地図上のタイル（ポリゴン）またはアイコンにカーソルを合わせた際（スマホではタップ時）に、その陣地の取得情報（ユーザー名・取得/防衛日時）をツールチップ（Popup）で表示する機能を追加する。

## 対応背景

- ユーザーが「誰がいつそのタイルを取得/防衛したか」を地図上で即座に確認できるようにするため。
- docs/srd.md のマップビュー要件を満たしつつ、UX を向上させる。

## 変更内容 (Changes)

- **API**
  - `/api/tiles` および `/api/groups/[id]/tiles` で、`users` の `display_name` と `tiles` の `last_updated_at` を取得・返却するように変更。
- **GeoJSON**
  - `client/lib/h3-geojson.ts`: `TileRecord` に `display_name`, `last_updated_at` を追加。`tilesToGeoJSONFeatureCollection` および `tilesToIconPointFeatureCollection` の各 Feature の `properties` にこれらを含めるよう修正。
- **マップ UI**
  - `client/components/organisms/Map.tsx`:
    - ホバー/タップ対象の Feature 情報と座標を保持する `hoverInfo` ステートを追加。
    - `MapLibreMap` に `onMouseMove`, `onMouseLeave`, `onClick` を追加し、`h3-hex-fill` / `h3-hex-user-icon` レイヤー上の Feature を `queryRenderedFeatures` で検知して `hoverInfo` を更新・クリア。
    - 対象レイヤー上では `cursor: pointer` に変更。
    - `@vis.gl/react-maplibre` の `Popup` を利用し、`hoverInfo` がある場合にアバター・ユーザー名・「取得/防衛: YYYY/MM/DD HH:mm」を表示。

## 動作確認手順 (How to Test)

1. ログインし、グループにタイルが存在する地図画面を開く。
2. **PC**: 地図上のタイル（六角形の塗り）またはズームイン時のユーザーアイコンにマウスを合わせる。→ 対象ユーザーの名前と「取得/防衛: YYYY/MM/DD HH:mm」が Popup で表示されること。カーソルが pointer になること。
3. **スマホサイズ（DevTools でモバイル表示）**: タイルまたはアイコンをタップする。→ 同様に Popup でユーザー名と日時が表示されること。
4. マウスを地図外に出す、または別のタイルに移すと Popup が消えること。

## 影響範囲と懸念事項 (Impact & Concerns)

- タイル API のレスポンスに `display_name`, `last_updated_at` が追加されるため、既存のフロントでこれらのキーを参照していない限り後方互換性は維持される。
- なし

## チェックリスト (Checklist)

- [ ] 必要なテストコードを追加・更新し、すべてパスしている
- [ ] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある
- [ ] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている
