### PR TITLE
スマホ版レスポンシブる対応

### DIFF
--- a/client/components/molecules/UserProfileBadge.tsx
+++ b/client/components/molecules/UserProfileBadge.tsx
@@ -19,7 +19,7 @@ export function UserProfileBadge({
       className={`flex items-center gap-2 text-sm text-gray-700 ${className}`.trim()}
     >
       <Avatar src={iconUrl} size="md" />
-      <span className="font-medium">{displayName ?? "ユーザー"}</span>
+      <span className="hidden font-medium sm:inline-block">{displayName ?? "ユーザー"}</span>
     </span>
   );
 }

--- a/client/components/organisms/Header.tsx
+++ b/client/components/organisms/Header.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Users } from "lucide-react";
 import { getSessionUserId } from "@/lib/session";
 import { getSupabaseServer } from "@/lib/supabase";
 import { LogoLink, StravaConnectButton, LogoutButton } from "@/components/atoms";
@@ -14,7 +15,7 @@ export interface HeaderUser {
  */
 export function HeaderView({ user }: { user: HeaderUser | null }) {
   return (
-    <header className="sticky top-0 z-10 border-b border-gray-200 bg-white">
+    <header className="sticky top-0 z-50 border-b border-gray-200 bg-white">
       <div className="mx-auto flex h-14 max-w-4xl items-center justify-between px-4">
         <LogoLink />
 
@@ -23,21 +24,10 @@ export function HeaderView({ user }: { user: HeaderUser | null }) {
             <>
               <Link
                 href="/groups"
-                className="text-sm text-zinc-600 hover:text-zinc-900"
+                className="flex items-center gap-1.5 text-sm text-zinc-600 hover:text-zinc-900"
               >
-                マイグループ
-              </Link>
-              <Link
-                href="/join"
-                className="text-sm text-zinc-600 hover:text-zinc-900"
-              >
-                参加
-              </Link>
-              <Link
-                href="/groups/new"
-                className="text-sm text-zinc-600 hover:text-zinc-900"
-              >
-                作成
+                <Users className="h-4 w-4 shrink-0" aria-hidden />
+                <span className="hidden sm:inline">マイグループ</span>
               </Link>
               <NotificationBell />
               <UserProfileBadge


### PR DESCRIPTION
## 概要 (Context)

ヘッダーのスマホ向けUI改善と、通知ドロップダウンの z-index による表示バグを修正します。

## 対応背景

- ナビゲーションが多くスマホで窮屈なため「マイグループ」に整理し、レスポンシブでアイコンのみ／アイコン＋テキストを切り替えたい
- ユーザー名もスマホではアバターのみ表示にしたい
- 地図画面のグループ選択UI（z-20）の背後に通知ドロップダウンが隠れる問題を解消したい

## 変更内容 (Changes)

- ヘッダーから「参加」「作成」リンクを削除し、「マイグループ」のみ残した
- 「マイグループ」に lucide-react の Users アイコンを追加し、スマホではアイコンのみ・sm以上で「アイコン＋マイグループ」テキスト表示に変更
- UserProfileBadge のユーザー名を `<span className="hidden sm:inline-block">` で囲み、スマホではアバターのみ表示に変更
- ヘッダー全体の `z-10` を `z-50` に変更し、通知ドロップダウンが地図のグループ選択UIより手前に表示されるようにした

## 動作確認手順 (How to Test)

1. スマホサイズ（ビューポート幅を狭める）で、ヘッダーの「マイグループ」がアイコンのみ表示され、テキストが非表示になることを確認する
2. スマホサイズで、ユーザー名（テキスト）が非表示になり、アバターアイコンのみ表示されることを確認する
3. 地図画面で通知ベルを開いたとき、通知ドロップダウンが地図のグループ選択UIより手前に表示されることを確認する

## 影響範囲と懸念事項 (Impact & Concerns)

- なし

## チェックリスト (Checklist)

- [ ] 必要なテストコードを追加・更新し、すべてパスしている
- [ ] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある
- [ ] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている
