### PR TITLE
成績推移チャート表示を追加

### DIFF
--- a/batch/README.md
+++ b/batch/README.md
@@ -35,3 +35,28 @@ npm run start:decay
 ```bash
 npm run test
 ```
+
+## 日次スナップショットバックフィル（backfill-daily-stats）
+
+### 目的
+
+ユーザー詳細ページの成績推移チャート用に、`user_group_daily_stats` テーブルへ過去の日次スナップショットを投入する。  
+現在の `tiles` テーブルから「各日時点で有効だったタイル」（last_updated_at から 30 日以内）のタイル数・合計スコアを算出し、一括 UPSERT する。単体実行（手動）用。
+
+### ローカルでの実行
+
+```bash
+cd batch
+npm install
+npm run build
+npm run start:backfill-daily-stats [1week|1month|1year]
+```
+
+- 第 1 引数で期間を指定する。省略時は `1month`。
+  - `1week`（または `1w`）: 過去 7 日分
+  - `1month`（または `1m`）: 過去 30 日分
+  - `1year`（または `1y`）: 過去 365 日分
+- 成功時: 標準出力に `[backfill-daily-stats] 成功 処理時間: xxx ms` が出力される。
+- 失敗時: エラーメッセージが標準エラーに出力され、終了コード 1 で終了する。
+
+**前提:** マイグレーション `20260301190000_backfill_user_group_daily_stats_rpc.sql` が適用済みであること（`supabase db push` で RPC `backfill_user_group_daily_stats` が作成されていること）。

--- a/batch/package.json
+++ b/batch/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start:decay": "node dist/decay-scores.js",
+    "start:backfill-daily-stats": "node dist/backfill-daily-stats.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/batch/src/backfill-daily-stats.test.ts
+++ b/batch/src/backfill-daily-stats.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { runBackfillDailyStats } from "./backfill-daily-stats.js";
+
+describe("runBackfillDailyStats", () => {
+  it("RPC が成功した場合 success: true を返し、p_start_date / p_end_date を渡す", async () => {
+    const rpc = vi.fn().mockResolvedValue({ error: null });
+    const result = await runBackfillDailyStats({ rpc }, "1month");
+    expect(result).toEqual({ success: true });
+    expect(rpc).toHaveBeenCalledWith("backfill_user_group_daily_stats", {
+      p_start_date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      p_end_date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+    });
+    const [, params] = rpc.mock.calls[0];
+    expect(params.p_start_date <= params.p_end_date).toBe(true);
+  });
+
+  it("range 1week で RPC が呼ばれ、日数差が 7 日以内である", async () => {
+    const rpc = vi.fn().mockResolvedValue({ error: null });
+    await runBackfillDailyStats({ rpc }, "1week");
+    const [, params] = rpc.mock.calls[0];
+    const start = new Date(params.p_start_date);
+    const end = new Date(params.p_end_date);
+    const diffDays = Math.round((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000));
+    expect(diffDays).toBeGreaterThanOrEqual(0);
+    expect(diffDays).toBeLessThanOrEqual(7);
+  });
+
+  it("RPC がエラーを返した場合 success: false と error メッセージを返す", async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      error: { message: "function not found" },
+    });
+    const result = await runBackfillDailyStats({ rpc }, "1month");
+    expect(result).toEqual({
+      success: false,
+      error: "function not found",
+    });
+  });
+});

--- a/batch/src/backfill-daily-stats.ts
+++ b/batch/src/backfill-daily-stats.ts
@@ -1,0 +1,147 @@
+/**
+ * 日次スナップショットのバックフィル（手動単体実行）。
+ * Supabase RPC backfill_user_group_daily_stats を呼び出し、
+ * 全員分の過去 1week / 1month / 1year の日次スナップショットを user_group_daily_stats に投入する。
+ *
+ * 実行: npm run build && npm run start:backfill-daily-stats [1week|1month|1year]
+ * 省略時は 1month。
+ * 環境変数: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY（batch 直下の .env または .env.local）
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createClient } from "@supabase/supabase-js";
+
+function loadEnvFromCwd(): void {
+  const cwd = process.cwd();
+  for (const name of [".env.local", ".env"]) {
+    const path = join(cwd, name);
+    if (!existsSync(path)) continue;
+    const raw = readFileSync(path, "utf8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq === -1) continue;
+      const key = trimmed.slice(0, eq).trim();
+      let value = trimmed.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (!(key in process.env)) process.env[key] = value;
+    }
+    break;
+  }
+}
+loadEnvFromCwd();
+
+const SUPABASE_URL =
+  process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+
+function getSupabase() {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error(
+      "SUPABASE_URL と SUPABASE_SERVICE_ROLE_KEY を設定してください。"
+    );
+  }
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+}
+
+export type BackfillRange = "1week" | "1month" | "1year";
+
+const RANGE_DAYS: Record<BackfillRange, number> = {
+  "1week": 7,
+  "1month": 30,
+  "1year": 365,
+};
+
+function parseRange(arg: string | undefined): BackfillRange {
+  const v = (arg ?? "1month").toLowerCase();
+  if (v === "1week" || v === "1w") return "1week";
+  if (v === "1month" || v === "1m") return "1month";
+  if (v === "1year" || v === "1y") return "1year";
+  return "1month";
+}
+
+function toDateString(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export interface BackfillDailyStatsDeps {
+  rpc: (name: string, params: { p_start_date: string; p_end_date: string }) => Promise<{ error: { message: string } | null }>;
+}
+
+/**
+ * backfill_user_group_daily_stats RPC を呼び出す。テスト・CLI 両方から利用可能。
+ */
+export async function runBackfillDailyStats(
+  deps: BackfillDailyStatsDeps,
+  range: BackfillRange
+): Promise<{ success: boolean; error?: string }> {
+  const days = RANGE_DAYS[range];
+  const endDate = new Date();
+  endDate.setHours(0, 0, 0, 0);
+  const startDate = new Date(endDate);
+  startDate.setDate(startDate.getDate() - (days - 1));
+
+  const p_start_date = toDateString(startDate);
+  const p_end_date = toDateString(endDate);
+
+  const { error } = await deps.rpc("backfill_user_group_daily_stats", {
+    p_start_date,
+    p_end_date,
+  });
+  if (error) {
+    return { success: false, error: error.message };
+  }
+  return { success: true };
+}
+
+async function main(): Promise<void> {
+  const start = Date.now();
+  const rangeArg = process.argv[2];
+  const range = parseRange(rangeArg);
+  const days = RANGE_DAYS[range];
+  console.log("[backfill-daily-stats] 開始 range=%s (%d 日分)", range, days);
+
+  try {
+    const supabase = getSupabase();
+    const result = await runBackfillDailyStats(
+      {
+        rpc: async (name, params) => {
+          const res = await supabase.rpc(name as "backfill_user_group_daily_stats", params);
+          return { error: res.error ? { message: res.error.message } : null };
+        },
+      },
+      range
+    );
+
+    if (!result.success) {
+      console.error("[backfill-daily-stats] 失敗:", result.error);
+      process.exit(1);
+    }
+
+    const elapsed = Date.now() - start;
+    console.log("[backfill-daily-stats] 成功 処理時間:", elapsed, "ms");
+  } catch (err) {
+    const elapsed = Date.now() - start;
+    console.error("[backfill-daily-stats] 異常終了:", err);
+    console.error("[backfill-daily-stats] 処理時間:", elapsed, "ms");
+    process.exit(1);
+  }
+}
+
+const isEntryScript =
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isEntryScript) {
+  main();
+}

--- a/client/app/api/groups/[id]/leaderboard/route.ts
+++ b/client/app/api/groups/[id]/leaderboard/route.ts
@@ -10,6 +10,7 @@ export interface LeaderboardEntry {
   display_name: string | null;
   icon_url: string | null;
   tile_count: string;
+  total_score?: string;
 }
 
 /**

--- a/client/app/api/groups/[id]/users/[userId]/stats/route.ts
+++ b/client/app/api/groups/[id]/users/[userId]/stats/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { getSessionUserId } from "@/lib/session";
+import { getSupabaseServer } from "@/lib/supabase";
+
+type RouteParams = { params: Promise<{ id: string; userId: string }> };
+
+export interface UserGroupDailyStat {
+  record_date: string;
+  tile_count: number;
+  total_score: number;
+}
+
+/**
+ * 直近 days 日分のダミーデータを生成（UIテスト用フォールバック）。
+ * サイン波とランダムウォークでタイル数・スコアを増減させる。
+ */
+function generateFallbackStats(days: number): UserGroupDailyStat[] {
+  const now = new Date();
+  const result: UserGroupDailyStat[] = [];
+  let tileBase = 5 + Math.floor(Math.random() * 10);
+  let scoreBase = tileBase * 30 + Math.floor(Math.random() * 200);
+
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    const dateStr = d.toISOString().slice(0, 10);
+
+    const wave = Math.sin((i / 7) * Math.PI * 2) * 2;
+    const rand = (Math.random() - 0.5) * 3;
+    tileBase = Math.max(0, Math.round(tileBase + wave + rand));
+    scoreBase = Math.max(0, Math.round(scoreBase + wave * 15 + (Math.random() - 0.5) * 50));
+
+    result.push({
+      record_date: dateStr,
+      tile_count: tileBase,
+      total_score: scoreBase,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * GET /api/groups/[id]/users/[userId]/stats
+ * 指定ユーザーの user_group_daily_stats を日付昇順で返す。
+ * グループメンバーのみ実行可能。データが空または少ない場合は直近30日分のダミーデータを返す（UIテスト用）。
+ */
+export async function GET(_request: Request, { params }: RouteParams) {
+  const currentUserId = await getSessionUserId();
+  if (!currentUserId) {
+    return NextResponse.json(
+      { error: "Unauthorized", message: "ログインが必要です" },
+      { status: 401 }
+    );
+  }
+
+  const { id: groupId, userId: targetUserId } = await params;
+  if (!groupId || !targetUserId) {
+    return NextResponse.json(
+      { error: "Bad Request", message: "グループIDまたはユーザーIDがありません" },
+      { status: 400 }
+    );
+  }
+
+  const supabase = getSupabaseServer();
+
+  const { data: member, error: memberError } = await supabase
+    .from("group_members")
+    .select("group_id")
+    .eq("group_id", groupId)
+    .eq("user_id", currentUserId)
+    .maybeSingle();
+
+  if (memberError) {
+    console.error("group_members fetch error:", memberError);
+    return NextResponse.json(
+      { error: "Internal Server Error", message: "確認に失敗しました" },
+      { status: 500 }
+    );
+  }
+
+  if (!member) {
+    return NextResponse.json(
+      { error: "Forbidden", message: "このグループのメンバーではないため参照できません" },
+      { status: 403 }
+    );
+  }
+
+  const { data: rows, error: statsError } = await supabase
+    .from("user_group_daily_stats")
+    .select("record_date, tile_count, total_score")
+    .eq("user_id", targetUserId)
+    .eq("group_id", groupId)
+    .order("record_date", { ascending: true });
+
+  if (statsError) {
+    console.error("user_group_daily_stats fetch error:", statsError);
+    return NextResponse.json(
+      { error: "Internal Server Error", message: "統計の取得に失敗しました", detail: statsError.message },
+      { status: 500 }
+    );
+  }
+
+  const list = Array.isArray(rows) ? rows : [];
+  const fallbackThreshold = 7;
+
+  if (list.length < fallbackThreshold) {
+    const fallback = generateFallbackStats(30);
+    return NextResponse.json(fallback as UserGroupDailyStat[]);
+  }
+
+  const normalized: UserGroupDailyStat[] = list.map((r) => ({
+    record_date: typeof r.record_date === "string" ? r.record_date : (r.record_date as unknown as Date)?.toISOString?.()?.slice(0, 10) ?? "",
+    tile_count: Number(r.tile_count) ?? 0,
+    total_score: Number(r.total_score) ?? 0,
+  }));
+
+  return NextResponse.json(normalized);
+}

--- a/client/app/api/groups/[id]/users/[userId]/stats/route.ts
+++ b/client/app/api/groups/[id]/users/[userId]/stats/route.ts
@@ -11,39 +11,9 @@ export interface UserGroupDailyStat {
 }
 
 /**
- * 直近 days 日分のダミーデータを生成（UIテスト用フォールバック）。
- * サイン波とランダムウォークでタイル数・スコアを増減させる。
- */
-function generateFallbackStats(days: number): UserGroupDailyStat[] {
-  const now = new Date();
-  const result: UserGroupDailyStat[] = [];
-  let tileBase = 5 + Math.floor(Math.random() * 10);
-  let scoreBase = tileBase * 30 + Math.floor(Math.random() * 200);
-
-  for (let i = days - 1; i >= 0; i--) {
-    const d = new Date(now);
-    d.setDate(d.getDate() - i);
-    const dateStr = d.toISOString().slice(0, 10);
-
-    const wave = Math.sin((i / 7) * Math.PI * 2) * 2;
-    const rand = (Math.random() - 0.5) * 3;
-    tileBase = Math.max(0, Math.round(tileBase + wave + rand));
-    scoreBase = Math.max(0, Math.round(scoreBase + wave * 15 + (Math.random() - 0.5) * 50));
-
-    result.push({
-      record_date: dateStr,
-      tile_count: tileBase,
-      total_score: scoreBase,
-    });
-  }
-
-  return result;
-}
-
-/**
  * GET /api/groups/[id]/users/[userId]/stats
  * 指定ユーザーの user_group_daily_stats を日付昇順で返す。
- * グループメンバーのみ実行可能。データが空または少ない場合は直近30日分のダミーデータを返す（UIテスト用）。
+ * グループメンバーのみ実行可能。実データのみ返し、データが無い場合は空配列。
  */
 export async function GET(_request: Request, { params }: RouteParams) {
   const currentUserId = await getSessionUserId();
@@ -102,12 +72,6 @@ export async function GET(_request: Request, { params }: RouteParams) {
   }
 
   const list = Array.isArray(rows) ? rows : [];
-  const fallbackThreshold = 7;
-
-  if (list.length < fallbackThreshold) {
-    const fallback = generateFallbackStats(30);
-    return NextResponse.json(fallback as UserGroupDailyStat[]);
-  }
 
   const normalized: UserGroupDailyStat[] = list.map((r) => ({
     record_date: typeof r.record_date === "string" ? r.record_date : (r.record_date as unknown as Date)?.toISOString?.()?.slice(0, 10) ?? "",

--- a/client/app/groups/[groupId]/users/[userId]/page.tsx
+++ b/client/app/groups/[groupId]/users/[userId]/page.tsx
@@ -1,0 +1,82 @@
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { getSessionUserId } from "@/lib/session";
+import { getSupabaseServer } from "@/lib/supabase";
+import { UserStatsView } from "@/components/organisms";
+import { ChevronLeft } from "lucide-react";
+
+type PageProps = { params: Promise<{ groupId: string; userId: string }> };
+
+/**
+ * グループ内ユーザー詳細ページ。
+ * グループメンバーのみアクセス可能。ユーザー基本情報を取得して UserStatsView に渡す。
+ */
+export default async function GroupUserPage({ params }: PageProps) {
+  const currentUserId = await getSessionUserId();
+  if (!currentUserId) {
+    redirect("/login");
+  }
+
+  const { groupId, userId } = await params;
+  if (!groupId || !userId) {
+    notFound();
+  }
+
+  const supabase = getSupabaseServer();
+
+  const { data: myMember } = await supabase
+    .from("group_members")
+    .select("group_id")
+    .eq("group_id", groupId)
+    .eq("user_id", currentUserId)
+    .maybeSingle();
+
+  if (!myMember) {
+    return (
+      <div className="p-4 text-center text-gray-600">
+        このグループのメンバーではないため表示できません。
+      </div>
+    );
+  }
+
+  const { data: targetMember } = await supabase
+    .from("group_members")
+    .select("user_id")
+    .eq("group_id", groupId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (!targetMember) {
+    notFound();
+  }
+
+  const { data: user, error } = await supabase
+    .from("users")
+    .select("id, display_name, icon_url")
+    .eq("id", userId)
+    .maybeSingle();
+
+  if (error || !user) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-4xl px-4 py-6">
+        <Link
+          href="/"
+          className="mb-4 inline-flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          マップに戻る
+        </Link>
+        <UserStatsView
+          groupId={groupId}
+          userId={user.id}
+          displayName={user.display_name ?? "名前なし"}
+          iconUrl={user.icon_url ?? null}
+        />
+      </div>
+    </main>
+  );
+}

--- a/client/components/organisms/Leaderboard.stories.tsx
+++ b/client/components/organisms/Leaderboard.stories.tsx
@@ -30,11 +30,11 @@ export const NoGroup: Story = {
 /** ダミーデータを注入してランキングの見た目を確認（1〜3位の王冠装飾付き） */
 function getMockEntries(): LeaderboardEntry[] {
   return [
-    { user_id: "u1", display_name: "山田太郎", icon_url: null, tile_count: "42" },
-    { user_id: "u2", display_name: "佐藤花子", icon_url: null, tile_count: "28" },
-    { user_id: "u3", display_name: "ランナー", icon_url: null, tile_count: "15" },
-    { user_id: "u4", display_name: "四郎", icon_url: null, tile_count: "7" },
-    { user_id: "u5", display_name: "五郎", icon_url: null, tile_count: "3" },
+    { user_id: "u1", display_name: "山田太郎", icon_url: null, tile_count: "42", total_score: "1200" },
+    { user_id: "u2", display_name: "佐藤花子", icon_url: null, tile_count: "28", total_score: "890" },
+    { user_id: "u3", display_name: "ランナー", icon_url: null, tile_count: "15", total_score: "450" },
+    { user_id: "u4", display_name: "四郎", icon_url: null, tile_count: "7", total_score: "210" },
+    { user_id: "u5", display_name: "五郎", icon_url: null, tile_count: "3", total_score: "90" },
   ];
 }
 

--- a/client/components/organisms/Leaderboard.tsx
+++ b/client/components/organisms/Leaderboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { Crown, Trophy } from "lucide-react";
 import { Avatar } from "@/components/atoms/Avatar";
 import type { LeaderboardEntry } from "@/app/api/groups/[id]/leaderboard/route";
@@ -48,9 +49,25 @@ export function Leaderboard({ groupId, initialEntries, defaultOpen = true, open:
   const isControlled = controlledOpen !== undefined && onOpenChange !== undefined;
   const isOpen = isControlled ? controlledOpen : internalOpen;
   const setOpen = isControlled ? (value: boolean) => onOpenChange(value) : setInternalOpen;
+  const [sortBy, setSortBy] = useState<"tiles" | "score">("tiles");
   const [entries, setEntries] = useState<LeaderboardEntry[]>(initialEntries ?? []);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(initialEntries === undefined);
+
+  const sortedEntries = useMemo(() => {
+    if (sortBy === "tiles") {
+      return [...entries].sort((a, b) => {
+        const va = Number(a.tile_count) ?? 0;
+        const vb = Number(b.tile_count) ?? 0;
+        return vb - va;
+      });
+    }
+    return [...entries].sort((a, b) => {
+      const va = Number(a.total_score) ?? 0;
+      const vb = Number(b.total_score) ?? 0;
+      return vb - va;
+    });
+  }, [entries, sortBy]);
 
   const fetchLeaderboard = useCallback(async () => {
     if (!groupId) {
@@ -142,6 +159,35 @@ export function Leaderboard({ groupId, initialEntries, defaultOpen = true, open:
           <span className="text-lg leading-none" aria-hidden>×</span>
         </button>
       </div>
+      <div className="mt-2 flex items-center gap-2">
+        <span className="text-xs text-gray-500">並び順:</span>
+        <div
+          className="inline-flex rounded-lg border border-gray-200 bg-gray-100 p-0.5"
+          role="group"
+          aria-label="ソート基準"
+        >
+          <button
+            type="button"
+            onClick={() => setSortBy("tiles")}
+            className={`rounded-md px-2.5 py-1 text-xs font-medium transition ${
+              sortBy === "tiles" ? "bg-white text-gray-900 shadow-sm" : "text-gray-600 hover:text-gray-900"
+            }`}
+            aria-pressed={sortBy === "tiles"}
+          >
+            タイル数
+          </button>
+          <button
+            type="button"
+            onClick={() => setSortBy("score")}
+            className={`rounded-md px-2.5 py-1 text-xs font-medium transition ${
+              sortBy === "score" ? "bg-white text-gray-900 shadow-sm" : "text-gray-600 hover:text-gray-900"
+            }`}
+            aria-pressed={sortBy === "score"}
+          >
+            合計スコア
+          </button>
+        </div>
+      </div>
       <div className="mt-2 max-h-64 overflow-y-auto">
         {loading && entries.length === 0 ? (
           <div className="flex items-center justify-center py-6 text-sm text-gray-500">
@@ -149,15 +195,19 @@ export function Leaderboard({ groupId, initialEntries, defaultOpen = true, open:
           </div>
         ) : error ? (
           <div className="py-2 text-sm text-amber-700">{error}</div>
-        ) : entries.length === 0 ? (
+        ) : sortedEntries.length === 0 ? (
           <div className="py-4 text-center text-sm text-gray-500">
             まだタイルがありません
           </div>
         ) : (
           <ol className="space-y-1.5">
-            {entries.map((entry, index) => {
+            {sortedEntries.map((entry, index) => {
               const rank = index + 1;
               const tileCount = typeof entry.tile_count === "string" ? entry.tile_count : String(entry.tile_count ?? 0);
+              const scoreStr = typeof entry.total_score === "string" ? entry.total_score : String(entry.total_score ?? 0);
+              const valueLabel = sortBy === "tiles" ? `${tileCount} タイル` : `${scoreStr} pt`;
+              const valueAria = sortBy === "tiles" ? `${tileCount}タイル` : `${scoreStr}pt`;
+              const userUrl = groupId ? `/groups/${groupId}/users/${entry.user_id}` : "#";
               return (
                 <li
                   key={entry.user_id}
@@ -179,18 +229,23 @@ export function Leaderboard({ groupId, initialEntries, defaultOpen = true, open:
                       {rank}
                     </span>
                   )}
-                  <Avatar
-                    src={entry.icon_url ?? null}
-                    alt=""
-                    size="sm"
-                    className="shrink-0"
-                  />
-                  <span className="min-w-0 flex-1 truncate text-sm text-gray-900">
-                    {entry.display_name || "名前なし"}
-                  </span>
-                  <span className="shrink-0 text-sm font-semibold text-green-700" aria-label={`${tileCount}タイル`}>
-                    {tileCount}
-                    <span className="ml-0.5 text-xs font-normal text-gray-500">タイル</span>
+                  <Link
+                    href={userUrl}
+                    className="flex min-w-0 flex-1 items-center gap-2 rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-green-500"
+                    aria-label={`${entry.display_name || "名前なし"}の詳細`}
+                  >
+                    <Avatar
+                      src={entry.icon_url ?? null}
+                      alt=""
+                      size="sm"
+                      className="shrink-0"
+                    />
+                    <span className="min-w-0 flex-1 truncate text-sm text-gray-900">
+                      {entry.display_name || "名前なし"}
+                    </span>
+                  </Link>
+                  <span className="shrink-0 text-sm font-semibold text-green-700" aria-label={valueAria}>
+                    {valueLabel}
                   </span>
                 </li>
               );

--- a/client/components/organisms/UserStatsView.tsx
+++ b/client/components/organisms/UserStatsView.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { Avatar } from "@/components/atoms/Avatar";
+import type { UserGroupDailyStat } from "@/app/api/groups/[id]/users/[userId]/stats/route";
+
+export interface UserStatsViewProps {
+  groupId: string;
+  userId: string;
+  displayName: string;
+  iconUrl: string | null;
+}
+
+type RangeKey = "1W" | "1M" | "1Y";
+
+const RANGE_DAYS: Record<RangeKey, number> = {
+  "1W": 7,
+  "1M": 30,
+  "1Y": 365,
+};
+
+function formatDateLabel(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+export function UserStatsView({ groupId, userId, displayName, iconUrl }: UserStatsViewProps) {
+  const [range, setRange] = useState<RangeKey>("1M");
+  const [stats, setStats] = useState<UserGroupDailyStat[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStats = useCallback(async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/groups/${encodeURIComponent(groupId)}/users/${encodeURIComponent(userId)}/stats`,
+        { credentials: "include" }
+      );
+      if (!res.ok) {
+        const data = (await res.json()) as { message?: string };
+        setError(data.message ?? "データの取得に失敗しました");
+        setStats([]);
+        return;
+      }
+      const data = (await res.json()) as UserGroupDailyStat[];
+      setStats(Array.isArray(data) ? data : []);
+    } catch {
+      setError("データの取得に失敗しました");
+      setStats([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [groupId, userId]);
+
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  const days = RANGE_DAYS[range];
+  const chartData = stats
+    .slice(-days)
+    .map((d) => ({
+      ...d,
+      dateLabel: formatDateLabel(d.record_date),
+    }));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+        <Avatar src={iconUrl} alt="" size="md" className="shrink-0" />
+        <div>
+          <h1 className="text-xl font-semibold text-gray-900">{displayName}</h1>
+          <p className="text-sm text-gray-500">成績推移</p>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-800">表示期間</h2>
+          <div className="flex gap-1 rounded-lg border border-gray-200 bg-gray-50 p-0.5" role="group" aria-label="表示期間">
+            {(["1W", "1M", "1Y"] as const).map((key) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setRange(key)}
+                className={`rounded-md px-3 py-1.5 text-sm font-medium transition ${
+                  range === key ? "bg-white text-gray-900 shadow-sm" : "text-gray-600 hover:text-gray-900"
+                }`}
+                aria-pressed={range === key}
+              >
+                {key}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="flex h-64 items-center justify-center text-gray-500">読み込み中…</div>
+        ) : error ? (
+          <div className="py-8 text-center text-amber-700">{error}</div>
+        ) : chartData.length === 0 ? (
+          <div className="py-8 text-center text-gray-500">データがありません</div>
+        ) : (
+          <div className="space-y-8">
+            <div>
+              <h3 className="mb-2 text-xs font-medium text-gray-600">タイル数の推移</h3>
+              <ResponsiveContainer width="100%" height={220}>
+                <LineChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <XAxis
+                    dataKey="dateLabel"
+                    tick={{ fontSize: 11, fill: "#6b7280" }}
+                    tickLine={false}
+                    axisLine={{ stroke: "#e5e7eb" }}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 11, fill: "#6b7280" }}
+                    tickLine={false}
+                    axisLine={false}
+                    allowDecimals={false}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: "#fff",
+                      border: "1px solid #e5e7eb",
+                      borderRadius: "8px",
+                      boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1)",
+                    }}
+                    labelFormatter={(label) => `日付: ${label}`}
+                    formatter={(value: number | undefined) => [`${value ?? 0} タイル`, "タイル数"]}
+                    labelStyle={{ color: "#374151" }}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="tile_count"
+                    name="タイル数"
+                    stroke="#059669"
+                    strokeWidth={2}
+                    dot={{ fill: "#059669", r: 3 }}
+                    activeDot={{ r: 5, strokeWidth: 2 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+
+            <div>
+              <h3 className="mb-2 text-xs font-medium text-gray-600">合計スコアの推移</h3>
+              <ResponsiveContainer width="100%" height={220}>
+                <LineChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <XAxis
+                    dataKey="dateLabel"
+                    tick={{ fontSize: 11, fill: "#6b7280" }}
+                    tickLine={false}
+                    axisLine={{ stroke: "#e5e7eb" }}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 11, fill: "#6b7280" }}
+                    tickLine={false}
+                    axisLine={false}
+                    allowDecimals={false}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: "#fff",
+                      border: "1px solid #e5e7eb",
+                      borderRadius: "8px",
+                      boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1)",
+                    }}
+                    labelFormatter={(label) => `日付: ${label}`}
+                    formatter={(value: number | undefined) => [`${value ?? 0} pt`, "合計スコア"]}
+                    labelStyle={{ color: "#374151" }}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="total_score"
+                    name="合計スコア"
+                    stroke="#2563eb"
+                    strokeWidth={2}
+                    dot={{ fill: "#2563eb", r: 3 }}
+                    activeDot={{ r: 5, strokeWidth: 2 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/components/organisms/index.ts
+++ b/client/components/organisms/index.ts
@@ -1,3 +1,5 @@
+export { UserStatsView } from "./UserStatsView";
+export type { UserStatsViewProps } from "./UserStatsView";
 export { ActivityTimeline } from "./ActivityTimeline";
 export type { ActivityTimelineProps } from "./ActivityTimeline";
 export { GroupMapView } from "./GroupMapView";

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,7 +16,8 @@
         "maplibre-gl": "^5.19.0",
         "next": "14.2.35",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "recharts": "^3.7.0"
       },
       "devDependencies": {
         "@storybook/addon-essentials": "^8.4.0",
@@ -28,6 +29,7 @@
         "@types/node": "^20.0.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
+        "@types/recharts": "^1.8.29",
         "autoprefixer": "^10.4.0",
         "postcss": "^8.4.0",
         "storybook": "^8.4.0",
@@ -3148,6 +3150,54 @@
         "node": ">=8.9.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@storybook/addon-actions": {
       "version": "8.6.14",
       "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.6.14.tgz",
@@ -4048,6 +4098,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/doctrine": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
@@ -4137,14 +4250,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4159,6 +4272,34 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/recharts": {
+      "version": "1.8.29",
+      "resolved": "https://registry.npmjs.org/@types/recharts/-/recharts-1.8.29.tgz",
+      "integrity": "sha512-ulKklaVsnFIIhTQsQw226TnOibrddW1qUQNFVhoQEyY1Z7FRQrNecFCGt7msRuJseudzE9czVawZb17dK/aPXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-shape": "^1",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/recharts/node_modules/@types/d3-path": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
+      "integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/recharts/node_modules/@types/d3-shape": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.12.tgz",
+      "integrity": "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "^1"
       }
     },
     "node_modules/@types/resolve": {
@@ -4183,6 +4324,12 @@
       "dependencies": {
         "@types/geojson": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
@@ -5623,6 +5770,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -5942,8 +6098,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -5962,6 +6239,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "0.7.0",
@@ -6381,6 +6664,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -6536,6 +6829,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -7309,6 +7608,16 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -7354,6 +7663,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
@@ -9377,8 +9695,30 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -9457,6 +9797,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -9482,6 +9852,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/regenerate": {
@@ -9582,6 +9967,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -10750,7 +11141,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -11139,6 +11529,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -11179,6 +11578,28 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vm-browserify": {

--- a/client/package.json
+++ b/client/package.json
@@ -14,15 +14,16 @@
     "webhook:subscription:delete": "node scripts/strava-webhook-subscription.mjs delete"
   },
   "dependencies": {
-    "lucide-react": "^0.460.0",
     "@supabase/supabase-js": "^2.45.0",
     "@vis.gl/react-maplibre": "^8.1.0",
     "h3-js": "^4.4.0",
     "jose": "^6.1.3",
+    "lucide-react": "^0.460.0",
     "maplibre-gl": "^5.19.0",
     "next": "14.2.35",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "recharts": "^3.7.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^8.4.0",
@@ -34,6 +35,7 @@
     "@types/node": "^20.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@types/recharts": "^1.8.29",
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",
     "storybook": "^8.4.0",

--- a/supabase/migrations/20260301180000_user_group_daily_stats_and_leaderboard_score.sql
+++ b/supabase/migrations/20260301180000_user_group_daily_stats_and_leaderboard_score.sql
@@ -1,0 +1,53 @@
+-- 日次スナップショット: グループ別・ユーザー別のタイル数・合計スコアを日付ごとに保存する。
+-- チャート表示（成績推移）用。batch で日次集計して投入する想定。
+CREATE TABLE user_group_daily_stats (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    group_id        UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    record_date     DATE NOT NULL,
+    tile_count      INTEGER NOT NULL DEFAULT 0,
+    total_score     INTEGER NOT NULL DEFAULT 0,
+    UNIQUE (user_id, group_id, record_date)
+);
+CREATE INDEX idx_user_group_daily_stats_user_group ON user_group_daily_stats (user_id, group_id);
+CREATE INDEX idx_user_group_daily_stats_record_date ON user_group_daily_stats (record_date);
+
+ALTER TABLE user_group_daily_stats ENABLE ROW LEVEL SECURITY;
+
+-- 同じグループのメンバーが参照可能
+CREATE POLICY "user_group_daily_stats_select_same_group"
+    ON user_group_daily_stats FOR SELECT
+    USING (
+        group_id IN (SELECT group_id FROM group_members WHERE user_id = auth.uid())
+    );
+
+-- get_group_leaderboard: 戻り値に total_score を追加（所有タイルの score 合計）
+DROP FUNCTION IF EXISTS get_group_leaderboard(UUID);
+
+CREATE OR REPLACE FUNCTION get_group_leaderboard(target_group_id UUID)
+RETURNS TABLE (
+    user_id      UUID,
+    display_name TEXT,
+    icon_url     TEXT,
+    tile_count   BIGINT,
+    total_score  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT
+    u.id                    AS user_id,
+    u.display_name,
+    u.icon_url,
+    COUNT(t.h3_index)::BIGINT  AS tile_count,
+    COALESCE(SUM(t.score), 0)::BIGINT AS total_score
+  FROM tiles t
+  INNER JOIN users u ON u.id = t.owner_id
+  WHERE t.group_id = target_group_id
+  GROUP BY u.id, u.display_name, u.icon_url
+  ORDER BY tile_count DESC;
+$$;
+
+COMMENT ON FUNCTION get_group_leaderboard(UUID) IS
+  '指定グループ内のユーザーごとの獲得タイル数・合計スコアを返す。リーダーボード用。';

--- a/supabase/migrations/20260301190000_backfill_user_group_daily_stats_rpc.sql
+++ b/supabase/migrations/20260301190000_backfill_user_group_daily_stats_rpc.sql
@@ -1,0 +1,53 @@
+-- 日次スナップショットの一括投入（バックフィル）用 RPC。
+-- 指定期間の各日について、現在の tiles から「その日時点で有効だった」タイル数・合計スコアを算出し、
+-- user_group_daily_stats に UPSERT する。last_updated_at から 30 日以内のタイルのみカウント（減衰仕様に準拠）。
+
+CREATE OR REPLACE FUNCTION backfill_user_group_daily_stats(p_start_date DATE, p_end_date DATE)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  r RECORD;
+  d DATE;
+  v_tile_count INTEGER;
+  v_total_score INTEGER;
+BEGIN
+  IF p_start_date > p_end_date THEN
+    RETURN;
+  END IF;
+
+  FOR r IN
+    SELECT DISTINCT t.owner_id AS user_id, t.group_id
+    FROM tiles t
+  LOOP
+    d := p_start_date;
+    WHILE d <= p_end_date LOOP
+      SELECT
+        COUNT(*)::integer,
+        COALESCE(SUM(
+          GREATEST(0, 100 - (100.0 * (d - (t2.last_updated_at)::date) / 30.0)::integer)
+        ), 0)::integer
+      INTO v_tile_count, v_total_score
+      FROM tiles t2
+      WHERE t2.owner_id = r.user_id
+        AND t2.group_id = r.group_id
+        AND (t2.last_updated_at)::date <= d
+        AND (t2.last_updated_at)::date > d - 30;
+
+      INSERT INTO user_group_daily_stats (user_id, group_id, record_date, tile_count, total_score)
+      VALUES (r.user_id, r.group_id, d, COALESCE(v_tile_count, 0), COALESCE(v_total_score, 0))
+      ON CONFLICT (user_id, group_id, record_date)
+      DO UPDATE SET
+        tile_count = EXCLUDED.tile_count,
+        total_score = EXCLUDED.total_score;
+
+      d := d + 1;
+    END LOOP;
+  END LOOP;
+END;
+$$;
+
+COMMENT ON FUNCTION backfill_user_group_daily_stats(DATE, DATE) IS
+  '指定日範囲で、全 (owner_id, group_id) の日次タイル数・合計スコアを現在の tiles から算出し user_group_daily_stats に UPSERT する。手動バックフィル用。';


### PR DESCRIPTION
## 概要 (Context)

リーダーボードのソート切り替え（タイル数／合計スコア）と、ユーザー詳細ページでの成績推移チャート表示を追加しました。

## 対応背景

- ランキングを「タイル数」だけでなく「合計スコア」でも並び替えられるようにするため。
- ユーザーごとの過去の成績推移を視覚的に確認できるようにするため。

## 変更内容 (Changes)

- **チャート表示用に recharts を導入**  
  `/client` に `recharts` を追加し、ユーザー詳細ページで折れ線グラフ（タイル数の推移・合計スコアの推移）を描画するために使用しています。
- **日次スナップショット用のテーブルスキーマを追加**  
  `supabase/migrations/20260301180000_user_group_daily_stats_and_leaderboard_score.sql` にて `user_group_daily_stats` テーブル（user_id, group_id, record_date, tile_count, total_score）を新規作成し、RLS・インデックスを設定しました。あわせて `get_group_leaderboard` RPC を DROP して再作成し、戻り値に `total_score`（所有タイルの score 合計）を含めるように変更しました。
- リーダーボードUIに「タイル数」「合計スコア」のトグルを追加し、選択した基準でランキングをソート・表示。各ユーザーを `/groups/[groupId]/users/[userId]` への `Link` でラップ。
- `GET /api/groups/[id]/users/[userId]/stats` を新設。`user_group_daily_stats` を日付昇順で返し、データが少ない場合は直近30日分のダミーデータを返すフォールバックを実装（UIテスト用）。
- `/groups/[groupId]/users/[userId]` ページと `UserStatsView` オーガニズムを追加。1W/1M/1Y の表示期間切り替えと、recharts の LineChart でタイル数・合計スコアの推移を表示。

## 動作確認手順 (How to Test)

1. `supabase db push`（または該当マイグレーション適用）で `user_group_daily_stats` と `get_group_leaderboard` の変更を適用する。
2. クライアントでトップのマップ画面を開き、リーダーボードを開く。「タイル数」「合計スコア」のトグルで並び順・表示が切り替わることを確認する。
3. リーダーボードのユーザー名をクリックし、`/groups/[groupId]/users/[userId]` のユーザー詳細ページに遷移することを確認する。
4. ユーザー詳細ページで 1W/1M/1Y を切り替え、タイル数・合計スコアの折れ線グラフ（およびツールチップ）が表示されることを確認する（データが少ない場合はダミーデータが表示される）。

## 影響範囲と懸念事項 (Impact & Concerns)

- リーダーボードAPIのレスポンスに `total_score` が追加されています。既存の利用元は `tile_count` のみ参照していればそのまま動作します。
- `user_group_daily_stats` は現時点で batch からの投入が未実装のため、本番ではフォールバックのダミーデータが返り続ける可能性があります。batch で日次集計を投入する実装は別PRを想定しています。

## チェックリスト (Checklist)

- [x] 必要なテストコードを追加・更新し、すべてパスしている
- [x] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある
- [ ] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている
