### PR TITLE
feat: add privacy policy and terms of service pages for Strava review

### DIFF
--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -3,16 +3,22 @@ import Link from "next/link";
 /**
  * プライバシーポリシーページ。Strava API 公開審査およびユーザー向けの法務情報。
  */
-export default function PrivacyPage() {
+export default function PrivacyPage({
+  searchParams,
+}: {
+  searchParams: { from?: string };
+}) {
+  const fromSettings = searchParams.from === "settings";
+
   return (
     <main className="min-h-[calc(100vh-3.5rem)] bg-zinc-50 px-4 py-10">
       <article className="mx-auto max-w-3xl">
         <div className="mb-8">
           <Link
-            href="/"
+            href={fromSettings ? "/settings" : "/"}
             className="text-sm text-zinc-500 hover:text-zinc-700"
           >
-            ← トップへ
+            {fromSettings ? "← 設定へ戻る" : "← トップへ"}
           </Link>
         </div>
 

--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link";
+
+/**
+ * プライバシーポリシーページ。Strava API 公開審査およびユーザー向けの法務情報。
+ */
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-[calc(100vh-3.5rem)] bg-zinc-50 px-4 py-10">
+      <article className="mx-auto max-w-3xl">
+        <div className="mb-8">
+          <Link
+            href="/"
+            className="text-sm text-zinc-500 hover:text-zinc-700"
+          >
+            ← トップへ
+          </Link>
+        </div>
+
+        <h1 className="mb-8 text-2xl font-bold tracking-tight text-zinc-900 sm:text-3xl">
+          プライバシーポリシー
+        </h1>
+
+        <div className="space-y-8 text-base leading-relaxed text-zinc-700">
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-zinc-900">
+              1. Strava から取得するデータと利用目的
+            </h2>
+            <p className="mb-2">
+              本サービスは、Strava API を通じて以下のデータを取得し、陣取りゲームの提供に利用します。
+            </p>
+            <ul className="list-inside list-disc space-y-1 pl-2">
+              <li>
+                <strong>プロフィール情報</strong>
+                ：表示名、プロフィール画像（アイコン）— グループ内での識別およびランキング・活動ログの表示に使用します。
+              </li>
+              <li>
+                <strong>アクティビティの位置情報（GPS データ）</strong>
+                ：ランニング等のアクティビティに含まれる緯度・経度 — 通過したエリア（H3 タイル）の陣地獲得・防衛・減衰の判定に使用します。
+              </li>
+            </ul>
+            <p className="mt-3">
+              上記データは、陣取りゲームの進行、グループ内でのランキング表示、Activity Log（奪取・防衛などの履歴）の表示にのみ利用し、これら以外の目的では利用しません。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-zinc-900">
+              2. データの保存と保護方針
+            </h2>
+            <p>
+              取得したデータは、本サービスのバックエンド（Supabase）において安全に保存・管理します。アクセス制御、通信の暗号化（HTTPS）等の一般的なセキュリティ対策を講じ、第三者への不正な開示・漏洩を防ぐよう努めます。Strava から取得する権限は、サービスに必要な最小限の範囲に限定しています。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-zinc-900">
+              3. アカウント削除時のデータ消去
+            </h2>
+            <p>
+              ユーザーは、設定画面から自らのアカウントを削除することができます。アカウント削除時には、当該ユーザーに紐づくプロフィール情報、陣地データ、活動ログ等のデータを削除し、復元できない状態にします。削除の手順は、アプリ内の「アカウント設定」から「アカウントを完全に削除する」により実行できます。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-zinc-900">
+              4. ユーザーの同意について
+            </h2>
+            <p>
+              本サービスを利用することにより、本プライバシーポリシーに記載したデータの取得・利用・保存に同意したものとみなします。Strava の認可画面において、本サービスがリクエストする権限（プロフィール・アクティビティの読み取り等）を許可していただく必要があります。同意いただけない場合、本サービスはご利用いただけません。
+            </p>
+          </section>
+
+          <section>
+            <p className="text-sm text-zinc-500">
+              本ポリシーは、法令の変更やサービス内容の変更に応じて改定することがあります。重要な変更がある場合は、アプリ内または適切な方法でお知らせします。
+            </p>
+          </section>
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/client/app/terms/page.tsx
+++ b/client/app/terms/page.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+
+/**
+ * 利用規約ページ。Strava API 公開審査およびユーザー向けの法務情報。
+ */
+export default function TermsPage() {
+  return (
+    <main className="min-h-[calc(100vh-3.5rem)] bg-zinc-50 px-4 py-10">
+      <article className="mx-auto max-w-3xl">
+        <div className="mb-8">
+          <Link
+            href="/"
+            className="text-sm text-zinc-500 hover:text-zinc-700"
+          >
+            ← トップへ
+          </Link>
+        </div>
+
+        <h1 className="mb-8 text-2xl font-bold tracking-tight text-zinc-900 sm:text-3xl">
+          利用規約
+        </h1>
+
+        <div className="space-y-8 text-base leading-relaxed text-zinc-700">
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-zinc-900">
+              1. サービスの目的と自己責任での利用
+            </h2>
+            <p className="mb-2">
+              本サービスは、Strava に記録されたランニング等のアクティビティに基づき、通過したエリアを「陣地」として可視化する陣取りゲームを提供するものです。本サービスの利用は、すべてユーザーご自身の責任で行ってください。
+            </p>
+            <p className="mb-2">
+              <strong>位置情報ゲームに伴う注意事項（免責事項）</strong>
+              ：本サービスは、走行ルートや陣地の獲得を楽しむためのものです。利用にあたっては、以下の点を遵守してください。
+            </p>
+            <ul className="list-inside list-disc space-y-1 pl-2">
+              <li>
+                <strong>交通ルールの遵守</strong>
+                ：走行時は、道路交通法および現地の交通ルールを守り、安全を最優先に行動してください。
+              </li>
+              <li>
+                <strong>危険な場所への立ち入り禁止</strong>
+                ：私有地・立入禁止区域・工事現場・災害危険区域など、立ち入りが禁止または危険な場所には入らないでください。陣地獲得を目的とした無理なルート選択による事故・トラブルについて、運営は一切の責任を負いません。
+              </li>
+              <li>
+                <strong>体調・環境の自己管理</strong>
+                ：熱中症、転倒、不審者等への対策はユーザー自身で行い、無理のない範囲でご利用ください。
+              </li>
+            </ul>
+            <p className="mt-3">
+              上記に違反した利用や、それに起因する損害について、運営は責任を負いかねます。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-zinc-900">
+              2. アカウントの取り扱い（Strava アカウントとの連携）
+            </h2>
+            <p>
+              本サービスは、Strava の OAuth による認証を利用します。利用開始には、Strava アカウントとの連携および本サービスが求める権限の許可が必要です。Strava の利用規約・プライバシーポリシーにも従ってご利用ください。グループへの参加は、招待リンク経由でのみ可能です。アカウントの削除は、本アプリの設定画面から行うことができ、削除後はデータが消去されます。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-zinc-900">
+              3. 禁止事項
+            </h2>
+            <p className="mb-2">
+              以下の行為は禁止します。
+            </p>
+            <ul className="list-inside list-disc space-y-1 pl-2">
+              <li>
+                <strong>チート行為</strong>
+                ：虚偽の位置情報の送信、不正なツール・スクリプトの使用、Strava のデータを改ざんしての登録など、公平なゲーム進行を妨げる行為。
+              </li>
+              <li>
+                <strong>Strava API の不正利用</strong>
+                ：Strava の API 利用規約に反する利用、過度なリクエスト、他者になりすましてのアクセスなど。
+              </li>
+              <li>
+                その他、法令または Strava の利用規約に違反する行為、他のユーザーや第三者に迷惑・損害を与える行為。
+              </li>
+            </ul>
+            <p className="mt-3">
+              禁止事項に該当する行為が確認された場合、アカウントの停止または削除等の対応を行うことがあります。
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-zinc-900">
+              4. 免責事項と規約の変更
+            </h2>
+            <p className="mb-2">
+              <strong>免責事項</strong>
+              ：本サービスは「現状のまま」提供されます。サービスの中止・変更・不具合、または利用に起因するいかなる損害についても、運営は責任を負いません。位置情報ゲームの利用に伴う事故・トラブルは、前述のとおりユーザーの自己責任でご対応ください。
+            </p>
+            <p>
+              <strong>規約の変更</strong>
+              ：本規約は、必要に応じて変更することがあります。重要な変更がある場合は、アプリ内または適切な方法でお知らせします。変更後の利用規約の効力発生日以降にサービスを利用した場合、変更後の規約に同意したものとみなします。
+            </p>
+          </section>
+
+          <section>
+            <p className="text-sm text-zinc-500">
+              本規約は、日本法に準拠し、本サービスに関する争議については、運営の本拠地を管轄する裁判所を専属的合意管轄とします。
+            </p>
+          </section>
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/client/app/terms/page.tsx
+++ b/client/app/terms/page.tsx
@@ -3,16 +3,22 @@ import Link from "next/link";
 /**
  * 利用規約ページ。Strava API 公開審査およびユーザー向けの法務情報。
  */
-export default function TermsPage() {
+export default function TermsPage({
+  searchParams,
+}: {
+  searchParams: { from?: string };
+}) {
+  const fromSettings = searchParams.from === "settings";
+
   return (
     <main className="min-h-[calc(100vh-3.5rem)] bg-zinc-50 px-4 py-10">
       <article className="mx-auto max-w-3xl">
         <div className="mb-8">
           <Link
-            href="/"
+            href={fromSettings ? "/settings" : "/"}
             className="text-sm text-zinc-500 hover:text-zinc-700"
           >
-            ← トップへ
+            {fromSettings ? "← 設定へ戻る" : "← トップへ"}
           </Link>
         </div>
 

--- a/client/components/organisms/LandingPage.tsx
+++ b/client/components/organisms/LandingPage.tsx
@@ -1,5 +1,6 @@
 import { StravaConnectButton } from "@/components/atoms";
 import { ArrowRightIcon } from "@/components/ui";
+import Link from "next/link";
 
 /**
  * 未ログイン時に表示するランディングページ。
@@ -116,6 +117,21 @@ export function LandingPage() {
           />
         </div>
       </section>
+
+      {/* フッター: 法務リンク */}
+      <footer
+        className="border-t border-zinc-800/80 bg-zinc-950 px-4 py-6"
+        aria-label="フッター"
+      >
+        <div className="mx-auto flex max-w-5xl justify-center gap-6 text-center text-sm text-zinc-500">
+          <Link href="/terms" className="hover:text-zinc-300">
+            利用規約
+          </Link>
+          <Link href="/privacy" className="hover:text-zinc-300">
+            プライバシーポリシー
+          </Link>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/client/components/organisms/LoginView.tsx
+++ b/client/components/organisms/LoginView.tsx
@@ -41,6 +41,14 @@ export function LoginView({ authUrl, errorMessage }: LoginViewProps) {
           トップへ戻る
         </Link>
       </div>
+      <footer className="mt-8 flex w-full max-w-sm justify-center gap-4 text-center text-xs text-zinc-400">
+        <Link href="/terms" className="hover:text-zinc-600">
+          利用規約
+        </Link>
+        <Link href="/privacy" className="hover:text-zinc-600">
+          プライバシーポリシー
+        </Link>
+      </footer>
     </main>
   );
 }

--- a/client/components/organisms/SettingsView.tsx
+++ b/client/components/organisms/SettingsView.tsx
@@ -55,12 +55,12 @@ export function SettingsView({ displayName, iconUrl }: SettingsViewProps) {
         <h2 className="mb-3 text-sm font-medium text-zinc-500">法務情報</h2>
         <ul className="space-y-2 text-sm">
           <li>
-            <Link href="/terms" className="text-zinc-700 underline hover:text-zinc-900">
+            <Link href="/terms?from=settings" className="text-zinc-700 underline hover:text-zinc-900">
               利用規約
             </Link>
           </li>
           <li>
-            <Link href="/privacy" className="text-zinc-700 underline hover:text-zinc-900">
+            <Link href="/privacy?from=settings" className="text-zinc-700 underline hover:text-zinc-900">
               プライバシーポリシー
             </Link>
           </li>

--- a/client/components/organisms/SettingsView.tsx
+++ b/client/components/organisms/SettingsView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Avatar } from "@/components/atoms";
 
 export interface SettingsViewProps {
@@ -47,6 +48,23 @@ export function SettingsView({ displayName, iconUrl }: SettingsViewProps) {
       <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
         <h2 className="mb-3 text-sm font-medium text-zinc-500">通知設定</h2>
         <p className="text-sm text-zinc-400">（準備中）</p>
+      </section>
+
+      {/* 法務情報 */}
+      <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+        <h2 className="mb-3 text-sm font-medium text-zinc-500">法務情報</h2>
+        <ul className="space-y-2 text-sm">
+          <li>
+            <Link href="/terms" className="text-zinc-700 underline hover:text-zinc-900">
+              利用規約
+            </Link>
+          </li>
+          <li>
+            <Link href="/privacy" className="text-zinc-700 underline hover:text-zinc-900">
+              プライバシーポリシー
+            </Link>
+          </li>
+        </ul>
       </section>
 
       {/* Danger Zone */}


### PR DESCRIPTION
## 概要 (Context)

Strava API の公開審査に必要な「プライバシーポリシー」と「利用規約」のページを追加し、ログイン前・ログイン後の両方からアクセスできる導線を設けました。

## 対応背景

- Strava API 公開審査において、プライバシーポリシーおよび利用規約の掲示と、ユーザーが容易にアクセスできることが求められるため。
- 陣取りゲーム（位置情報利用）に伴う免責事項・禁止事項を明文化するため。

## 変更内容 (Changes)

- `/client/app/privacy/page.tsx`: プライバシーポリシーページを新規作成（Strava から取得するデータ・利用目的、保存・保護方針、アカウント削除時のデータ消去、ユーザーの同意）
- `/client/app/terms/page.tsx`: 利用規約ページを新規作成（サービスの目的・自己責任、交通ルール遵守・危険区域立ち入り禁止等の免責、アカウント取扱、禁止事項、免責・規約変更）
- `LoginView.tsx`: ログイン画面フッターに「利用規約」「プライバシーポリシー」リンクを追加
- `LandingPage.tsx`: ランディングページフッターに同リンクを追加
- `SettingsView.tsx`: 設定画面に「法務情報」セクションを追加し、両ページへのリンクを配置

## 動作確認手順 (How to Test)

1. 未ログインでトップ（/）にアクセスし、ページ最下部のフッターに「利用規約」「プライバシーポリシー」リンクが表示されることを確認する。
2. /login にアクセスし、認可カード下部のフッターに同リンクが表示されることを確認する。リンクをクリックし、それぞれ /terms・/privacy に遷移することを確認する。
3. ログイン後、設定画面（/settings）を開き、「法務情報」セクション内の「利用規約」「プライバシーポリシー」リンクから各ページに遷移できることを確認する。
4. /privacy および /terms のページが、max-w-3xl のドキュメントスタイルで読みやすく表示されることを確認する。

## 影響範囲と懸念事項 (Impact & Concerns)

- なし（新規ページとリンク追加のみ。既存認証・API には変更なし）

## チェックリスト (Checklist)

- [ ] 必要なテストコードを追加・更新し、すべてパスしている（本 PR は静的ページ・リンク追加のため、既存 E2E や Storybook で確認可能）
- [ ] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある
- [ ] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している（不要）
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている（フッター・法務情報セクションの追加のため、Preview で確認推奨）


Made with [Cursor](https://cursor.com)