### PR TITLE
style: Strava Connect ボタンをブランドガイドライン準拠に更新

### DIFF
--- a/client/components/atoms/StravaConnectButton.tsx
+++ b/client/components/atoms/StravaConnectButton.tsx
@@ -2,6 +2,22 @@
 
 import Link from "next/link";
 
+/** Strava公式ロゴアイコン（白・オレンジ背景用） */
+function StravaLogoIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.598h4.172L10.463 0l-7 13.828h4.169" />
+    </svg>
+  );
+}
+
 export interface StravaConnectButtonProps {
   href: string;
   children?: React.ReactNode;
@@ -14,21 +30,23 @@ export interface StravaConnectButtonProps {
 }
 
 const baseClass =
-  "inline-flex items-center justify-center gap-2 font-medium text-white transition focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2";
+  "inline-flex items-center justify-center font-semibold text-white transition focus:outline-none focus:ring-2 focus:ring-[#fc4c02] focus:ring-offset-2";
+
 const variantClasses = {
   default:
-    "rounded-xl bg-orange-500 px-8 py-4 text-base font-semibold shadow-lg shadow-orange-500/25 hover:bg-orange-600 hover:shadow-orange-500/30 focus:ring-offset-zinc-950",
+    "gap-3 rounded-lg bg-[#fc4c02] py-3 px-6 text-base shadow-md hover:bg-[#e34402] focus:ring-offset-zinc-950",
   compact:
-    "rounded-lg bg-orange-500 px-4 py-2 text-sm hover:bg-orange-600 focus:ring-offset-2",
+    "gap-2 rounded-md bg-[#fc4c02] py-2 px-4 text-sm shadow-md hover:bg-[#e34402] focus:ring-offset-2",
 };
 
 /**
  * Strava 連携（Connect with Strava）用のリンクボタン。
+ * Strava API ブランドガイドラインに準拠したデザイン。
  */
 export function StravaConnectButton({
   href,
   children = "Connect with Strava",
-  variant = "compact",
+  variant = "default",
   rightIcon,
   className = "",
   "data-testid": dataTestId,
@@ -39,6 +57,7 @@ export function StravaConnectButton({
       className={`${baseClass} ${variantClasses[variant]} ${className}`.trim()}
       data-testid={dataTestId ?? "connect-strava"}
     >
+      <StravaLogoIcon className="h-5 w-5 shrink-0" />
       <span>{children}</span>
       {rightIcon}
     </Link>


### PR DESCRIPTION
## 概要 (Context)

Strava API の公開審査（レビュー）提出に向け、Connect with Strava ボタンを公式ブランドガイドラインに完全準拠させました。

## 対応背景

- 審査要件として、Connect with Strava ボタンは公式ガイドラインに沿ったデザインである必要があるため
- 背景色・テキスト・アイコン・余白などを公式カラー #FC4C02 および推奨表現に統一

## 変更内容 (Changes)

- `StravaConnectButton` の背景色を公式オレンジ `#fc4c02` に変更（ホバー時 `#e34402`）
- 文言を「Connect with Strava」に統一し、白文字・font-semibold で表示
- ボタン左側に Strava ロゴ（SVG）を白抜きで追加
- レイアウトを flex + gap-3、padding（py-3 px-6）、角丸（rounded-lg）、shadow-md で統一

## 動作確認手順 (How to Test)

1. ログイン画面のボタンが Strava 公式のオレンジ色（#fc4c02）になり、正しいテキストと余白で表示されること
2. ボタン左に Strava ロゴが表示され、ホバーで少し暗いオレンジ（#e34402）に変化すること
3. ランディングページ・ヘッダーなど他画面の Connect with Strava ボタンも同様にブランドカラーで表示されること

## 影響範囲と懸念事項 (Impact & Concerns)

- 既存の `StravaConnectButton` 利用箇所（LoginView / LandingPage / Header）はそのまま利用可能。`rightIcon` は互換のため残しています。

## チェックリスト (Checklist)

- [ ] 必要なテストコードを追加・更新し、すべてパスしている
- [ ] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある
- [ ] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている
