### PR TITLE
ci: add GitHub Actions workflow for daily batch processing

### DIFF
--- a/.github/workflows/daily-batch.yml
+++ b/.github/workflows/daily-batch.yml
@@ -1,0 +1,38 @@
+# 日次バッチ（スコア減衰等）を毎日自動実行するワークフロー
+# 日本時間 午前0時 = UTC 15:00（前日）
+name: Daily Batch
+
+on:
+  schedule:
+    # 毎日 15:00 UTC = 日本時間 翌日 00:00（深夜）
+    - cron: "0 15 * * *"
+  workflow_dispatch:
+
+jobs:
+  daily-batch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: batch/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ./batch
+        run: npm ci
+
+      - name: Build
+        working-directory: ./batch
+        run: npm run build
+
+      - name: Run decay-scores (daily batch)
+        working-directory: ./batch
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: npm run start:decay


### PR DESCRIPTION
## 概要 (Context)

日次バッチ（スコア減衰処理 decay-scores 等）を毎日自動実行するための GitHub Actions ワークフローを追加する。

## 対応背景

/batch のスコア減衰処理を定期実行する仕組みが必要なため、GitHub Actions のスケジュール実行と手動実行を定義した。

## 変更内容 (Changes)

- `.github/workflows/daily-batch.yml` を新規作成
  - `schedule`: 毎日 15:00 UTC（日本時間 翌日 00:00）に cron 実行
  - `workflow_dispatch`: Actions タブから手動実行可能
  - `ubuntu-latest` で checkout / Node.js 20 セットアップ / `batch` で `npm ci` → `npm run build` → `npm run start:decay` を実行
  - 環境変数 `SUPABASE_URL` と `SUPABASE_SERVICE_ROLE_KEY` を GitHub Secrets から渡すよう設定

## 動作確認手順 (How to Test)

1. リポジトリの Actions タブで「Daily Batch」ワークフローを開く
2. 「Run workflow」から `workflow_dispatch` で手動実行（Secrets 設定後）
3. ジョブが成功し、decay-scores が実行されることを確認

## 影響範囲と懸念事項 (Impact & Concerns)

- **GitHub Secrets の登録が必須です。** 本ワークフローを動作させるには、GitHub リポジトリの **Settings → Secrets and variables → Actions** で以下の Secrets を登録してください。
  - `SUPABASE_URL`: Supabase プロジェクトの URL
  - `SUPABASE_SERVICE_ROLE_KEY`: Supabase のサービスロールキー（server-side 用）
- 未登録のまま実行すると、decay-scores 内で環境変数未設定エラーとなりジョブが失敗します。

## チェックリスト (Checklist)

- [ ] 必要なテストコードを追加・更新し、すべてパスしている（ワークフロー追加のため既存テストで足りる想定）
- [ ] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある（該当なし）
- [x] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している（GitHub Secrets の登録を明記）
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている（該当なし）


Made with [Cursor](https://cursor.com)