### PR TITLE
feat: enforce RLS and add security policies

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -92,8 +92,26 @@ make db-push
 | `20260228000000_initial_schema.sql`                     | 初期スキーマ（users, groups, group_members, tiles 等）       |
 | `20260228100000_tiles_score_and_users_token.sql`        | tiles の score / last_updated_at、users の Strava トークン列 |
 | `20260301000000_ensure_tiles_score_and_users_token.sql` | 上記カラムの冪等な追加（履歴未適用・手動のみ環境の救済用）   |
+| `20250303120000_enforce_rls.sql`                        | RLS 一括有効化とポリシー定義（users / tiles / group_members 等） |
 
 3 本目は `ADD COLUMN IF NOT EXISTS` のため、既にカラムがある DB では何も変わらない。**「column tiles.score does not exist」が出た場合も、`make db-push` で未適用の 3 本目が走れば解消する。**
+
+## セキュリティ・RLSポリシー
+
+Anon Key 経由の不正な読み書きを防ぐため、対象テーブルで Row Level Security（RLS）を有効化している。**Service Role Key は RLS をバイパスする**ため、バックエンドのみが書き込みを行う想定。
+
+適用内容はマイグレーション `20250303120000_enforce_rls.sql` で定義されている。
+
+| テーブル | RLS | クライアント（Anon/Authenticated）で可能な操作 | 条件・備考 |
+| -------- | --- | ---------------------------------------------- | ---------- |
+| **users** | 有効 | SELECT, UPDATE | 自分の行のみ。条件: `auth.uid() = id`。INSERT/DELETE はポリシーなし（バックエンドのみ）。 |
+| **tiles** | 有効 | SELECT のみ | 全行読み取り可（`USING (true)`）。INSERT/UPDATE/DELETE はポリシーなしで、Service Role を持つバックエンドのみ書き込み可能。 |
+| **group_members** | 有効 | SELECT のみ | 自分が所属しているレコードのみ。条件: `auth.uid() = user_id`。書き込みはバックエンドのみ。 |
+| **groups** | 有効 | なし | ポリシーを付与していないため、Anon/Authenticated では行の参照・更新不可。必要ならバックエンド経由または別マイグレーションでポリシーを追加する。 |
+| **activity_logs** | 有効 | なし | 上記と同様。クライアントからの直接アクセスは不可。 |
+
+- 認証は Supabase Auth の `auth.uid()` を前提とする。
+- クライアントからは Anon Key または Authenticated セッションで接続し、上記ポリシーの範囲内でのみアクセスできる。
 
 ## トラブルシューティング
 

--- a/supabase/migrations/20250303120000_enforce_rls.sql
+++ b/supabase/migrations/20250303120000_enforce_rls.sql
@@ -1,0 +1,49 @@
+-- Enforce RLS on all target tables to prevent unauthorized read/write via Anon Key.
+-- Service Role Key (backend) bypasses RLS; only intended client access is allowed.
+
+-- =============================================================
+-- 1. Enable ROW LEVEL SECURITY
+-- =============================================================
+
+ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE groups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE group_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE activity_logs ENABLE ROW LEVEL SECURITY;
+
+-- =============================================================
+-- 2. users: 自分のデータのみ SELECT / UPDATE 可能
+-- =============================================================
+
+DROP POLICY IF EXISTS "users_select_own" ON users;
+CREATE POLICY "users_select_own" ON users
+  FOR SELECT USING (auth.uid() = id);
+
+DROP POLICY IF EXISTS "users_update_own" ON users;
+CREATE POLICY "users_update_own" ON users
+  FOR UPDATE USING (auth.uid() = id);
+
+-- =============================================================
+-- 3. tiles: 誰でも SELECT 可能。INSERT/UPDATE/DELETE はポリシーなし
+-- （Service Role を持つバックエンドのみ書き込み可能）
+-- =============================================================
+
+DROP POLICY IF EXISTS "tiles_select_same_group" ON tiles;
+DROP POLICY IF EXISTS "tiles_select_all" ON tiles;
+CREATE POLICY "tiles_select_all" ON tiles
+  FOR SELECT USING (true);
+
+-- =============================================================
+-- 4. group_members: 自分が所属しているレコードのみ SELECT 可能
+-- =============================================================
+
+DROP POLICY IF EXISTS "group_members_select_same_group" ON group_members;
+DROP POLICY IF EXISTS "group_members_select_own" ON group_members;
+CREATE POLICY "group_members_select_own" ON group_members
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- =============================================================
+-- 5. groups / activity_logs: RLS のみ有効化
+-- ポリシーは付与しないため、Anon/Authenticated ではアクセス不可。
+-- 必要に応じてバックエンド（Service Role）または別マイグレーションでポリシーを追加すること。
+-- =============================================================


### PR DESCRIPTION
## 概要 (Context)

Supabase の対象テーブルに Row Level Security（RLS）を適用し、Anon Key 経由での不正なデータ読み書きを防ぐ。あわせて `supabase/README.md` にセキュリティ・RLSポリシーの仕様を追記し、運用・レビュー時に参照できるようにする。

## 対応背景

- スキーマで RLS が有効化されていない状態では、Anon Key で全行の読み書きが可能となり、重大なセキュリティリスクがある。
- RLS を一括で有効化し、テーブルごとに必要なポリシーを定義するマイグレーションを追加した。
- どのテーブルでどの操作が誰に許可されているかを、人間が読める形で README に残す必要があるため、`supabase/README.md` に「セキュリティ・RLSポリシー」を追加した。

## 変更内容 (Changes)

- `supabase/migrations/20250303120000_enforce_rls.sql` を追加（既存 PR で実施済み）: users / groups / group_members / tiles / activity_logs で RLS を有効化し、users（SELECT・UPDATE 自分のみ）、tiles（SELECT 全件・書き込みはポリシーなし）、group_members（SELECT 自分の所属のみ）のポリシーを定義。
- `supabase/README.md` に「セキュリティ・RLSポリシー」セクションを追加: 上記 5 テーブルについて、RLS の有無・クライアントで可能な操作・条件を表形式で記載。マイグレーション一覧に `20250303120000_enforce_rls.sql` を追記。

## 動作確認手順 (How to Test)

1. リポジトリルートで `make db-push` を実行し、RLS マイグレーションが適用されることを確認する。
2. Supabase ダッシュボードの Table Editor または SQL Editor で、Anon Key 相当の権限ではポリシー外の行が参照・更新できないことを確認する（必要に応じて Service Role と比較）。
3. `supabase/README.md` を開き、「セキュリティ・RLSポリシー」の表と説明が意図どおりであることを確認する。

## 影響範囲と懸念事項 (Impact & Concerns)

- 適用後はクライアント（Anon/Authenticated）はポリシーで許可された範囲でのみテーブルにアクセス可能。groups / activity_logs は現状ポリシーなしのため、クライアントからは直接参照不可。必要であればバックエンド経由または別マイグレーションでポリシーを追加すること。
- 既存のバックエンドが Service Role Key で書き込みしている場合は、従来どおり RLS をバイパスするため影響なし。

## チェックリスト (Checklist)

- [ ] 必要なテストコードを追加・更新し、すべてパスしている
- [ ] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある
- [ ] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている