### PR TITLE
refactor: migrate user upsert to BFF in strava callback

### DIFF
--- a/client/app/api/auth/strava/callback/route.ts
+++ b/client/app/api/auth/strava/callback/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSupabaseServer } from "@/lib/supabase";
 import {
   createSessionToken,
   getSessionCookieOptions,
@@ -88,30 +87,53 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${baseRedirect}/login?error=token_encryption`);
   }
 
-  const supabase = getSupabaseServer();
-  const { data: user, error: upsertError } = await supabase
-    .from("users")
-    .upsert(
-      {
-        strava_id: athlete.id,
-        display_name: displayName,
-        icon_url: iconUrl,
-        strava_access_token: encryptedAccess,
-        strava_refresh_token: encryptedRefresh,
-        strava_token_expires_at: expiresAt,
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: "strava_id" }
-    )
-    .select("id")
-    .single();
+  const backendUrl = process.env.BACKEND_API_URL?.replace(/\/$/, "") ?? "";
+  if (!backendUrl) {
+    console.error("User sync failed: BACKEND_API_URL is not configured");
+    return NextResponse.redirect(`${baseRedirect}/login?error=config`);
+  }
 
-  if (upsertError || !user?.id) {
-    console.error("Supabase users upsert error:", upsertError);
+  const syncPayload = {
+    strava_id: athlete.id,
+    display_name: displayName,
+    icon_url: iconUrl,
+    strava_access_token: encryptedAccess,
+    strava_refresh_token: encryptedRefresh,
+    strava_token_expires_at: expiresAt,
+  };
+
+  let syncRes: Response;
+  try {
+    syncRes = await fetch(`${backendUrl}/users/sync`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(syncPayload),
+    });
+  } catch (e) {
+    console.error("User sync request failed:", e);
     return NextResponse.redirect(`${baseRedirect}/login?error=upsert`);
   }
 
-  const token = await createSessionToken(user.id);
+  if (!syncRes.ok) {
+    const text = await syncRes.text();
+    console.error("User sync failed:", syncRes.status, text);
+    return NextResponse.redirect(`${baseRedirect}/login?error=upsert`);
+  }
+
+  let syncData: { id?: string };
+  try {
+    syncData = (await syncRes.json()) as { id?: string };
+  } catch {
+    console.error("User sync: invalid JSON response");
+    return NextResponse.redirect(`${baseRedirect}/login?error=upsert`);
+  }
+
+  if (!syncData?.id) {
+    console.error("User sync: response missing id");
+    return NextResponse.redirect(`${baseRedirect}/login?error=upsert`);
+  }
+
+  const token = await createSessionToken(syncData.id);
   const response = NextResponse.redirect(baseRedirect);
   response.cookies.set(SESSION_COOKIE_NAME, token, getSessionCookieOptions());
   return response;

--- a/client/app/api/groups/join/route.ts
+++ b/client/app/api/groups/join/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSessionUserId } from "@/lib/session";
-import { getSupabaseServer } from "@/lib/supabase";
 
 /**
  * POST /api/groups/join
- * 招待コードでグループに参加し、group_members にレコードを追加する。
- * Body: { invite_code: string }
+ * 招待コードでグループ参加をバックエンドAPI (BFF) に委譲する。
+ * Body: { invite_code: string }。BFF へは { invite_code, user_id } を送信。
  */
 export async function POST(request: NextRequest) {
   const userId = await getSessionUserId();
@@ -35,47 +34,41 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const supabase = getSupabaseServer();
-
-  const { data: group, error: groupError } = await supabase
-    .from("groups")
-    .select("id")
-    .eq("invite_code", inviteCode)
-    .maybeSingle();
-
-  if (groupError) {
-    console.error("groups fetch error:", groupError);
+  const backendUrl = process.env.BACKEND_API_URL?.replace(/\/$/, "") ?? "";
+  if (!backendUrl) {
+    console.error("POST /api/groups/join: BACKEND_API_URL is not configured");
     return NextResponse.json(
-      { error: "Internal Server Error", message: "グループの取得に失敗しました" },
+      { error: "Internal Server Error", message: "サーバー設定エラーです" },
       { status: 500 }
     );
   }
 
-  if (!group?.id) {
-    return NextResponse.json(
-      { error: "Not Found", message: "招待コードに一致するグループがありません" },
-      { status: 404 }
-    );
-  }
+  try {
+    const res = await fetch(`${backendUrl}/groups/join`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ invite_code: inviteCode, user_id: userId }),
+    });
 
-  const { error: insertError } = await supabase.from("group_members").insert({
-    group_id: group.id,
-    user_id: userId,
-  });
+    const data = await res.json().catch(() => ({}));
 
-  if (insertError) {
-    if (insertError.code === "23505") {
+    if (!res.ok) {
+      const message =
+        typeof data?.message === "string"
+          ? data.message
+          : "参加処理に失敗しました";
       return NextResponse.json(
-        { error: "Conflict", message: "すでにこのグループに参加しています" },
-        { status: 409 }
+        { error: data?.error ?? "Internal Server Error", message },
+        { status: res.status }
       );
     }
-    console.error("group_members insert error:", insertError);
+
+    return NextResponse.json(data);
+  } catch (e) {
+    console.error("POST /api/groups/join: BFF request failed:", e);
     return NextResponse.json(
       { error: "Internal Server Error", message: "参加処理に失敗しました" },
       { status: 500 }
     );
   }
-
-  return NextResponse.json({ ok: true, group_id: group.id });
 }

--- a/client/app/api/groups/route.ts
+++ b/client/app/api/groups/route.ts
@@ -1,19 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { randomBytes } from "crypto";
 import { getSessionUserId } from "@/lib/session";
-import { getSupabaseServer } from "@/lib/supabase";
-
-const INVITE_CODE_BYTES = 4; // 8 hex chars
-const MAX_RETRIES = 5;
-
-function generateInviteCode(): string {
-  return randomBytes(INVITE_CODE_BYTES).toString("hex");
-}
 
 /**
  * POST /api/groups
- * グループを新規作成し、作成者を group_members に追加する。
- * 招待コードはサーバーで自動生成する（Body: { name: string } のみ）。
+ * グループ新規作成をバックエンドAPI (BFF) に委譲する。
+ * Body: { name: string } のみ。BFF へは { name, user_id } を送信。
  */
 export async function POST(request: NextRequest) {
   const userId = await getSessionUserId();
@@ -43,52 +34,41 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const supabase = getSupabaseServer();
-  let lastError: unknown = null;
+  const backendUrl = process.env.BACKEND_API_URL?.replace(/\/$/, "") ?? "";
+  if (!backendUrl) {
+    console.error("POST /api/groups: BACKEND_API_URL is not configured");
+    return NextResponse.json(
+      { error: "Internal Server Error", message: "サーバー設定エラーです" },
+      { status: 500 }
+    );
+  }
 
-  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    const inviteCode = generateInviteCode();
-    const { data: newGroup, error: insertGroupError } = await supabase
-      .from("groups")
-      .insert({ name, invite_code: inviteCode })
-      .select("id, name, invite_code")
-      .single();
+  try {
+    const res = await fetch(`${backendUrl}/groups`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, user_id: userId }),
+    });
 
-    if (!insertGroupError) {
-      const { error: insertMemberError } = await supabase
-        .from("group_members")
-        .insert({ group_id: newGroup.id, user_id: userId });
+    const data = await res.json().catch(() => ({}));
 
-      if (insertMemberError) {
-        console.error("group_members insert error:", insertMemberError);
-        return NextResponse.json(
-          { error: "Internal Server Error", message: "メンバー登録に失敗しました" },
-          { status: 500 }
-        );
-      }
-
-      return NextResponse.json({
-        ok: true,
-        group_id: newGroup.id,
-        name: newGroup.name,
-        invite_code: newGroup.invite_code,
-      });
+    if (!res.ok) {
+      const message =
+        typeof data?.message === "string"
+          ? data.message
+          : "グループの作成に失敗しました";
+      return NextResponse.json(
+        { error: data?.error ?? "Internal Server Error", message },
+        { status: res.status }
+      );
     }
 
-    if (insertGroupError.code === "23505") {
-      lastError = insertGroupError;
-      continue;
-    }
-    console.error("groups insert error:", insertGroupError);
+    return NextResponse.json(data);
+  } catch (e) {
+    console.error("POST /api/groups: BFF request failed:", e);
     return NextResponse.json(
       { error: "Internal Server Error", message: "グループの作成に失敗しました" },
       { status: 500 }
     );
   }
-
-  console.error("groups insert conflict after retries:", lastError);
-  return NextResponse.json(
-    { error: "Conflict", message: "招待コードの生成に失敗しました。しばらくしてから再試行してください。" },
-    { status: 409 }
-  );
 }


### PR DESCRIPTION
## 概要 (Context)

既存の `feature/bff-user-sync-frontend` の BFF 化に合わせ、グループ作成・グループ参加の API Route からも Supabase への直接操作をやめ、バックエンドAPI（BFF）へプロキシするように変更しました。

## 対応背景

- `POST /api/groups` および `POST /api/groups/join` で `getSupabaseServer()` により `groups` / `group_members` へ直接 insert していた。
- セキュリティと責務分離のため、DB 操作は BFF に集約し、Next.js の API Route は入力検証と BFF への中継のみ行う形に統一する。

## 変更内容 (Changes)

- **client/app/api/groups/route.ts**
  - `getSupabaseServer()` および `groups` / `group_members` への insert を削除。
  - 招待コード生成（`randomBytes`）を削除（BFF 側で実施する前提）。
  - `BACKEND_API_URL/groups` へ `{ name, user_id }` を POST する `fetch` に置き換え。BFF のレスポンスをそのまま返却し、非 OK 時はステータスとメッセージを転送。
- **client/app/api/groups/join/route.ts**
  - `getSupabaseServer()` および `groups` の select・`group_members` への insert を削除。
  - `BACKEND_API_URL/groups/join` へ `{ invite_code, user_id }` を POST する `fetch` に置き換え。BFF のレスポンス・ステータスを転送。
- 上記両ファイルから Supabase 関連のインポートを削除。

## 動作確認手順 (How to Test)

1. バックエンドAPI に `POST /groups` および `POST /groups/join` を実装・起動する（別PRまたは既存実装を想定）。
2. クライアントの `BACKEND_API_URL` をその BFF の URL に設定する。
3. ログイン後、グループ作成画面から新規グループを作成し、成功時に `ok: true` と `group_id` 等が返ることを確認する。
4. 招待コードでグループ参加を実行し、成功時に `ok: true` と `group_id` が返ることを確認する。無効な招待コードで 404、重複参加で 409 となることを確認する。

## 影響範囲と懸念事項 (Impact & Concerns)

- バックエンドAPI に **POST /groups**（Body: `{ name, user_id }`）および **POST /groups/join**（Body: `{ invite_code, user_id }`）の実装が必要です。レスポンス形式は従来の Next.js API と揃える（成功: `{ ok: true, group_id, ... }`、エラー: `{ error, message }` と適切な HTTP ステータス）とフロントの変更は最小限で済みます。

## チェックリスト (Checklist)

- [ ] 必要なテストコードを追加・更新し、すべてパスしている
- [ ] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある
- [ ] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている