### PR TITLE
feat: add /users/sync endpoint for BFF architecture

### DIFF
--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -24,3 +24,44 @@ npm install
 - **起動:** `npm run build` の後に `npm run webhook-server`（`backend-api` ディレクトリで実行すること）。
 - デフォルトで `http://localhost:3001/webhook/activity` で待ち受け（`PORT` 環境変数で変更可）。
 - **環境変数:** 起動時に **backend-api 直下の `.env.local` または `.env`** を自動読み込みする。`SUPABASE_URL`（または `NEXT_PUBLIC_SUPABASE_URL`）と `SUPABASE_SERVICE_ROLE_KEY` が必須。client で Strava トークンを暗号化して保存している場合は、復号用に **`STRAVA_TOKEN_ENCRYPTION_KEY`** を client と同一の値で設定する（未設定なら DB の平文トークンをそのまま使用）。`backend-api/.env.example` をコピーして `backend-api/.env.local` を作成し、値を設定する。
+
+## BFF エンドポイント（Backend For Frontend）
+
+フロントエンドからの直接 DB 操作を廃止し、バックエンド経由で行うための API。いずれも `POST`、Content-Type: `application/json`。同一の Webhook サーバー（`npm run webhook-server`）で待ち受ける。
+
+### POST /users/sync
+
+ユーザー情報（Strava トークン含む）を受け取り、トークンを暗号化して `users` テーブルに upsert する。
+
+- **リクエストボディ（JSON）**
+  - `strava_id` (number, 必須): Strava の Athlete ID
+  - `access_token` (string, 必須): Strava アクセストークン（平文。サーバー側で暗号化して保存）
+  - `refresh_token` (string, 必須): Strava リフレッシュトークン（平文。サーバー側で暗号化して保存）
+  - `display_name` (string, 任意): 表示名。省略時は `User {strava_id}`
+  - `profile_image_url` / `icon_url` (string | null, 任意): アイコン URL
+  - `strava_token_expires_at` (string | null, 任意): トークン有効期限（ISO 8601）
+- **レスポンス**
+  - 成功: `200` + `{ "ok": true }`
+  - 失敗: `400`（必須項目不足・不正）/ `500`（暗号化失敗・DB エラー） + `{ "error": "メッセージ" }`
+
+### POST /groups
+
+グループ名を受け取り、招待コードを自動生成（重複時はリトライ）して `groups` と `group_members` に insert する。
+
+- **リクエストボディ（JSON）**
+  - `name` (string, 必須): グループ名
+  - `user_id` (string, 必須): 作成者ユーザーの UUID（フロントのセッション等で取得した id）
+- **レスポンス**
+  - 成功: `200` + `{ "ok": true, "group_id": "uuid", "name": "グループ名", "invite_code": "8文字16進" }`
+  - 失敗: `400`（name 空・user_id 不正）/ `409`（招待コード衝突がリトライ上限超過）/ `500` + `{ "error": "メッセージ" }`
+
+### POST /groups/join
+
+招待コードを受け取り、対象グループを検索して `group_members` に insert する。
+
+- **リクエストボディ（JSON）**
+  - `invite_code` (string, 必須): 招待コード（8 文字 16 進）
+  - `user_id` (string, 必須): 参加するユーザーの UUID
+- **レスポンス**
+  - 成功: `200` + `{ "ok": true, "group_id": "uuid" }`
+  - 失敗: `400`（招待コード空・user_id 不正）/ `404`（招待コードに一致するグループなし）/ `409`（既に参加済み）/ `500` + `{ "error": "メッセージ" }`

--- a/backend-api/src/bff/groups.test.ts
+++ b/backend-api/src/bff/groups.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi } from "vitest";
+import { createGroup, joinGroup } from "./groups.js";
+
+const validUserId = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("createGroup", () => {
+  it("name が空の場合は 400", async () => {
+    const mockFrom = vi.fn(() => ({}));
+    const supabase = { from: mockFrom };
+    const result = await createGroup(supabase as never, { name: "", user_id: validUserId });
+    expect(result).toEqual({ ok: false, statusCode: 400, error: "Missing or invalid name" });
+  });
+
+  it("user_id が不正な場合は 400", async () => {
+    const mockFrom = vi.fn(() => ({}));
+    const supabase = { from: mockFrom };
+    const result = await createGroup(supabase as never, { name: "My Group", user_id: "not-a-uuid" });
+    expect(result).toEqual({ ok: false, statusCode: 400, error: "Missing or invalid user_id" });
+  });
+
+  it("groups insert 成功後に group_members insert が失敗した場合は 500", async () => {
+    const mockGroupsInsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { id: "g1", name: "My Group", invite_code: "abc12345" },
+          error: null,
+        }),
+      }),
+    });
+    const mockMembersInsert = vi.fn().mockResolvedValue({ error: { message: "FK violation" } });
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups") return { insert: mockGroupsInsert };
+      if (table === "group_members") return { insert: mockMembersInsert };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await createGroup(supabase as never, { name: "My Group", user_id: validUserId });
+    expect(result).toEqual({ ok: false, statusCode: 500, error: "FK violation" });
+  });
+
+  it("groups insert 成功・group_members 成功で ok: true と group_id, name, invite_code を返す", async () => {
+    const mockGroupsInsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { id: "g1", name: "My Group", invite_code: "deadbeef" },
+          error: null,
+        }),
+      }),
+    });
+    const mockMembersInsert = vi.fn().mockResolvedValue({ error: null });
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups") return { insert: mockGroupsInsert };
+      if (table === "group_members") return { insert: mockMembersInsert };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await createGroup(supabase as never, { name: "My Group", user_id: validUserId });
+    expect(result).toEqual({
+      ok: true,
+      group_id: "g1",
+      name: "My Group",
+      invite_code: "deadbeef",
+    });
+    expect(mockMembersInsert).toHaveBeenCalledWith({ group_id: "g1", user_id: validUserId });
+  });
+
+  it("groups insert が 23505 の場合はリトライし、最終的に全て衝突なら 409", async () => {
+    const mockGroupsInsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: null,
+          error: { code: "23505" },
+        }),
+      }),
+    });
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups") return { insert: mockGroupsInsert };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await createGroup(supabase as never, { name: "My Group", user_id: validUserId });
+    expect(result).toEqual({
+      ok: false,
+      statusCode: 409,
+      error: "Invite code conflict after retries",
+    });
+    expect(mockGroupsInsert).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe("joinGroup", () => {
+  it("invite_code が空の場合は 400", async () => {
+    const mockFrom = vi.fn(() => ({}));
+    const supabase = { from: mockFrom };
+    const result = await joinGroup(supabase as never, { invite_code: "", user_id: validUserId });
+    expect(result).toEqual({ ok: false, statusCode: 400, error: "Missing or invalid invite_code" });
+  });
+
+  it("user_id が不正な場合は 400", async () => {
+    const mockFrom = vi.fn(() => ({}));
+    const supabase = { from: mockFrom };
+    const result = await joinGroup(supabase as never, { invite_code: "abc12345", user_id: "x" });
+    expect(result).toEqual({ ok: false, statusCode: 400, error: "Missing or invalid user_id" });
+  });
+
+  it("招待コードに一致するグループが無い場合は 404", async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups")
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await joinGroup(supabase as never, {
+      invite_code: "nonexistent",
+      user_id: validUserId,
+    });
+    expect(result).toEqual({ ok: false, statusCode: 404, error: "Group not found" });
+  });
+
+  it("グループ取得エラー時は 500", async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups")
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: "DB error" } }),
+            }),
+          }),
+        };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await joinGroup(supabase as never, {
+      invite_code: "abc12345",
+      user_id: validUserId,
+    });
+    expect(result).toEqual({ ok: false, statusCode: 500, error: "DB error" });
+  });
+
+  it("既に参加済み（23505）の場合は 409", async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups")
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { id: "g1" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      if (table === "group_members")
+        return {
+          insert: vi.fn().mockResolvedValue({ error: { code: "23505" } }),
+        };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await joinGroup(supabase as never, {
+      invite_code: "abc12345",
+      user_id: validUserId,
+    });
+    expect(result).toEqual({ ok: false, statusCode: 409, error: "Already a member" });
+  });
+
+  it("参加成功時は ok: true と group_id を返す", async () => {
+    const mockMembersInsert = vi.fn().mockResolvedValue({ error: null });
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups")
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { id: "g1" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      if (table === "group_members") return { insert: mockMembersInsert };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await joinGroup(supabase as never, {
+      invite_code: "abc12345",
+      user_id: validUserId,
+    });
+    expect(result).toEqual({ ok: true, group_id: "g1" });
+    expect(mockMembersInsert).toHaveBeenCalledWith({ group_id: "g1", user_id: validUserId });
+  });
+});

--- a/backend-api/src/bff/groups.ts
+++ b/backend-api/src/bff/groups.ts
@@ -1,0 +1,126 @@
+/**
+ * BFF: グループ作成・参加ロジック（招待コード生成リトライ含む）
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { randomBytes } from "node:crypto";
+
+const INVITE_CODE_BYTES = 4;
+const MAX_RETRIES = 5;
+
+function generateInviteCode(): string {
+  return randomBytes(INVITE_CODE_BYTES).toString("hex");
+}
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+function isValidUUID(s: string): boolean {
+  return typeof s === "string" && UUID_REGEX.test(s);
+}
+
+export interface CreateGroupBody {
+  name: string;
+  user_id: string;
+}
+
+export type CreateGroupResult =
+  | { ok: true; group_id: string; name: string; invite_code: string }
+  | { ok: false; statusCode: number; error: string };
+
+export async function createGroup(
+  supabase: SupabaseClient,
+  body: CreateGroupBody
+): Promise<CreateGroupResult> {
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  if (!name) {
+    return { ok: false, statusCode: 400, error: "Missing or invalid name" };
+  }
+  if (!isValidUUID(body.user_id)) {
+    return { ok: false, statusCode: 400, error: "Missing or invalid user_id" };
+  }
+
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const inviteCode = generateInviteCode();
+    const { data: newGroup, error: insertGroupError } = await supabase
+      .from("groups")
+      .insert({ name, invite_code: inviteCode })
+      .select("id, name, invite_code")
+      .single();
+
+    if (!insertGroupError) {
+      const { error: insertMemberError } = await supabase
+        .from("group_members")
+        .insert({ group_id: newGroup.id, user_id: body.user_id });
+
+      if (insertMemberError) {
+        return { ok: false, statusCode: 500, error: insertMemberError.message };
+      }
+      return {
+        ok: true,
+        group_id: newGroup.id,
+        name: newGroup.name,
+        invite_code: newGroup.invite_code,
+      };
+    }
+
+    if (insertGroupError.code === "23505") {
+      lastError = insertGroupError;
+      continue;
+    }
+    return { ok: false, statusCode: 500, error: insertGroupError.message };
+  }
+
+  return {
+    ok: false,
+    statusCode: 409,
+    error: "Invite code conflict after retries",
+  };
+}
+
+export interface JoinGroupBody {
+  invite_code: string;
+  user_id: string;
+}
+
+export type JoinGroupResult =
+  | { ok: true; group_id: string }
+  | { ok: false; statusCode: number; error: string };
+
+export async function joinGroup(
+  supabase: SupabaseClient,
+  body: JoinGroupBody
+): Promise<JoinGroupResult> {
+  const inviteCode =
+    typeof body.invite_code === "string" ? body.invite_code.trim() : "";
+  if (!inviteCode) {
+    return { ok: false, statusCode: 400, error: "Missing or invalid invite_code" };
+  }
+  if (!isValidUUID(body.user_id)) {
+    return { ok: false, statusCode: 400, error: "Missing or invalid user_id" };
+  }
+
+  const { data: group, error: groupError } = await supabase
+    .from("groups")
+    .select("id")
+    .eq("invite_code", inviteCode)
+    .maybeSingle();
+
+  if (groupError) {
+    return { ok: false, statusCode: 500, error: groupError.message };
+  }
+  if (!group?.id) {
+    return { ok: false, statusCode: 404, error: "Group not found" };
+  }
+
+  const { error: insertError } = await supabase.from("group_members").insert({
+    group_id: group.id,
+    user_id: body.user_id,
+  });
+
+  if (insertError) {
+    if (insertError.code === "23505") {
+      return { ok: false, statusCode: 409, error: "Already a member" };
+    }
+    return { ok: false, statusCode: 500, error: insertError.message };
+  }
+  return { ok: true, group_id: group.id };
+}

--- a/backend-api/src/bff/users-sync.test.ts
+++ b/backend-api/src/bff/users-sync.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import { runUsersSync, type UsersSyncBody } from "./users-sync.js";
+
+const validBody: UsersSyncBody = {
+  strava_id: 12345,
+  access_token: "access",
+  refresh_token: "refresh",
+  display_name: "Test User",
+  profile_image_url: "https://example.com/icon.png",
+  strava_token_expires_at: "2025-12-31T00:00:00Z",
+};
+
+describe("runUsersSync", () => {
+  it("必須項目が欠けている場合は 400", async () => {
+    const encrypt = vi.fn((s: string) => `enc:${s}`);
+    const mockFrom = vi.fn(() => ({
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    }));
+    const supabase = { from: mockFrom };
+
+    const missingStravaId = { ...validBody, strava_id: undefined } as unknown as UsersSyncBody;
+    expect(await runUsersSync(supabase as never, missingStravaId, encrypt)).toEqual({
+      ok: false,
+      statusCode: 400,
+      error: "Missing or invalid strava_id, access_token, refresh_token",
+    });
+
+    const missingAccessToken = { ...validBody, access_token: undefined } as unknown as UsersSyncBody;
+    expect(await runUsersSync(supabase as never, missingAccessToken, encrypt)).toEqual({
+      ok: false,
+      statusCode: 400,
+      error: "Missing or invalid strava_id, access_token, refresh_token",
+    });
+  });
+
+  it("暗号化が null を返す場合は 500", async () => {
+    const encrypt = vi.fn(() => null);
+    const mockFrom = vi.fn(() => ({
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    }));
+    const supabase = { from: mockFrom };
+
+    const result = await runUsersSync(supabase as never, validBody, encrypt);
+    expect(result).toEqual({ ok: false, statusCode: 500, error: "Token encryption failed" });
+  });
+
+  it("upsert 成功時は ok: true", async () => {
+    const encrypt = vi.fn((s: string) => `enc:${s}`);
+    const mockUpsert = vi.fn().mockResolvedValue({ error: null });
+    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
+    const supabase = { from: mockFrom };
+
+    const result = await runUsersSync(supabase as never, validBody, encrypt);
+    expect(result).toEqual({ ok: true });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        strava_id: 12345,
+        display_name: "Test User",
+        icon_url: "https://example.com/icon.png",
+        strava_access_token: "enc:access",
+        strava_refresh_token: "enc:refresh",
+        strava_token_expires_at: "2025-12-31T00:00:00Z",
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it("display_name が空の場合は User {strava_id} になる", async () => {
+    const encrypt = vi.fn((s: string) => `enc:${s}`);
+    const mockUpsert = vi.fn().mockResolvedValue({ error: null });
+    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
+    const supabase = { from: mockFrom };
+    const body = { ...validBody, display_name: "", profile_image_url: null };
+
+    await runUsersSync(supabase as never, body, encrypt);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ display_name: "User 12345" }),
+      expect.any(Object)
+    );
+  });
+
+  it("Supabase upsert がエラーの場合は 500", async () => {
+    const encrypt = vi.fn((s: string) => `enc:${s}`);
+    const mockUpsert = vi.fn().mockResolvedValue({ error: { message: "DB error" } });
+    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
+    const supabase = { from: mockFrom };
+
+    const result = await runUsersSync(supabase as never, validBody, encrypt);
+    expect(result).toEqual({ ok: false, statusCode: 500, error: "DB error" });
+  });
+});

--- a/backend-api/src/bff/users-sync.ts
+++ b/backend-api/src/bff/users-sync.ts
@@ -1,0 +1,74 @@
+/**
+ * BFF: ユーザー情報の同期（トークン暗号化して users に upsert）
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface UsersSyncBody {
+  strava_id: number;
+  access_token: string;
+  refresh_token: string;
+  display_name?: string;
+  profile_image_url?: string | null;
+  icon_url?: string | null;
+  strava_token_expires_at?: string | null;
+}
+
+export type UsersSyncResult =
+  | { ok: true }
+  | { ok: false; statusCode: number; error: string };
+
+export type EncryptFn = (plaintext: string) => string | null;
+
+export async function runUsersSync(
+  supabase: SupabaseClient,
+  body: UsersSyncBody,
+  encrypt: EncryptFn
+): Promise<UsersSyncResult> {
+  if (
+    typeof body.strava_id !== "number" ||
+    typeof body.access_token !== "string" ||
+    typeof body.refresh_token !== "string"
+  ) {
+    return {
+      ok: false,
+      statusCode: 400,
+      error: "Missing or invalid strava_id, access_token, refresh_token",
+    };
+  }
+
+  const displayName =
+    typeof body.display_name === "string" && body.display_name.trim()
+      ? body.display_name.trim()
+      : `User ${body.strava_id}`;
+  const iconUrl = body.profile_image_url ?? body.icon_url ?? null;
+  const expiresAt =
+    typeof body.strava_token_expires_at === "string" &&
+    body.strava_token_expires_at
+      ? body.strava_token_expires_at
+      : null;
+
+  const encryptedAccess = encrypt(body.access_token);
+  const encryptedRefresh = encrypt(body.refresh_token);
+  if (!encryptedAccess || !encryptedRefresh) {
+    return { ok: false, statusCode: 500, error: "Token encryption failed" };
+  }
+
+  const row: Record<string, unknown> = {
+    strava_id: body.strava_id,
+    display_name: displayName,
+    icon_url: iconUrl,
+    strava_access_token: encryptedAccess,
+    strava_refresh_token: encryptedRefresh,
+    strava_token_expires_at: expiresAt,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { error } = await supabase
+    .from("users")
+    .upsert(row, { onConflict: "strava_id" });
+
+  if (error) {
+    return { ok: false, statusCode: 500, error: error.message };
+  }
+  return { ok: true };
+}

--- a/backend-api/src/utils/token-crypto.ts
+++ b/backend-api/src/utils/token-crypto.ts
@@ -1,8 +1,8 @@
 /**
- * Strava トークンの復号（client で暗号化した値を DB から読み取り時に復号）
- * client の lib/strava-token-crypto と同じ AES-256-GCM 形式。
+ * Strava トークンの暗号化・復号（client の lib/strava-token-crypto と同じ AES-256-GCM 形式）
+ * BFF ではバックエンドでトークンを暗号化して DB に保存する。
  */
-import { createDecipheriv } from "node:crypto";
+import { randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
 
 const ALG = "aes-256-gcm";
 const IV_LEN = 12;
@@ -14,6 +14,23 @@ function getKey(): Buffer | null {
   if (!raw || typeof raw !== "string") return null;
   const key = Buffer.from(raw, "base64");
   return key.length === KEY_LEN ? key : null;
+}
+
+/**
+ * トークンを暗号化し、base64(iv + ciphertext + authTag) を返す。
+ * STRAVA_TOKEN_ENCRYPTION_KEY が未設定の場合は null を返す。
+ */
+export function encryptStravaToken(plaintext: string): string | null {
+  const key = getKey();
+  if (!key) return null;
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALG, key, iv);
+  const enc = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, enc, tag]).toString("base64");
 }
 
 /**

--- a/backend-api/src/webhook-server.ts
+++ b/backend-api/src/webhook-server.ts
@@ -12,7 +12,7 @@ import {
   processActivityDelete,
   createDefaultDeps,
 } from "./services/strava-webhook.js";
-import { decryptStravaToken } from "./utils/token-crypto.js";
+import { decryptStravaToken, encryptStravaToken } from "./utils/token-crypto.js";
 
 function loadEnvFromCwd(): void {
   const cwd = process.cwd();
@@ -38,7 +38,8 @@ function loadEnvFromCwd(): void {
 loadEnvFromCwd();
 
 const PORT = Number(process.env.PORT) || 3001;
-const PATH = "/webhook/activity";
+const PATH_WEBHOOK = "/webhook/activity";
+const PATH_USERS_SYNC = "/users/sync";
 
 function getSupabase() {
   const url =
@@ -47,7 +48,7 @@ function getSupabase() {
   return createClient(url, key);
 }
 
-function parseBody(req: IncomingMessage): Promise<{ object_id: number; owner_id: number; action?: string } | null> {
+function parseJsonBody<T>(req: IncomingMessage): Promise<T | null> {
   return new Promise((resolve) => {
     let data = "";
     req.on("data", (chunk) => {
@@ -55,20 +56,7 @@ function parseBody(req: IncomingMessage): Promise<{ object_id: number; owner_id:
     });
     req.on("end", () => {
       try {
-        const body = JSON.parse(data) as unknown;
-        if (
-          body &&
-          typeof (body as { object_id?: number }).object_id === "number" &&
-          typeof (body as { owner_id?: number }).owner_id === "number"
-        ) {
-          resolve({
-            object_id: (body as { object_id: number }).object_id,
-            owner_id: (body as { owner_id: number }).owner_id,
-            action: typeof (body as { action?: string }).action === "string" ? (body as { action: string }).action : undefined,
-          });
-        } else {
-          resolve(null);
-        }
+        resolve(data ? (JSON.parse(data) as T) : null);
       } catch {
         resolve(null);
       }
@@ -76,11 +64,90 @@ function parseBody(req: IncomingMessage): Promise<{ object_id: number; owner_id:
   });
 }
 
+function parseWebhookBody(req: IncomingMessage): Promise<{ object_id: number; owner_id: number; action?: string } | null> {
+  return parseJsonBody(req).then((body) => {
+    if (
+      body &&
+      typeof (body as { object_id?: number }).object_id === "number" &&
+      typeof (body as { owner_id?: number }).owner_id === "number"
+    ) {
+      return {
+        object_id: (body as { object_id: number }).object_id,
+        owner_id: (body as { owner_id: number }).owner_id,
+        action: typeof (body as { action?: string }).action === "string" ? (body as { action: string }).action : undefined,
+      };
+    }
+    return null;
+  });
+}
+
+/** POST /users/sync のリクエストボディ */
+interface UsersSyncBody {
+  strava_id: number;
+  access_token: string;
+  refresh_token: string;
+  display_name?: string;
+  profile_image_url?: string | null;
+  icon_url?: string | null;
+  strava_token_expires_at?: string | null;
+}
+
+async function handleUsersSync(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await parseJsonBody<UsersSyncBody>(req);
+  if (!body || typeof body.strava_id !== "number" || typeof body.access_token !== "string" || typeof body.refresh_token !== "string") {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Missing or invalid strava_id, access_token, refresh_token" }));
+    return;
+  }
+
+  const displayName = typeof body.display_name === "string" && body.display_name.trim() ? body.display_name.trim() : `User ${body.strava_id}`;
+  const iconUrl = body.profile_image_url ?? body.icon_url ?? null;
+  const expiresAt = typeof body.strava_token_expires_at === "string" && body.strava_token_expires_at ? body.strava_token_expires_at : null;
+
+  const encryptedAccess = encryptStravaToken(body.access_token);
+  const encryptedRefresh = encryptStravaToken(body.refresh_token);
+  if (!encryptedAccess || !encryptedRefresh) {
+    console.error("[webhook-server] users/sync: token encryption failed (STRAVA_TOKEN_ENCRYPTION_KEY required)");
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Token encryption failed" }));
+    return;
+  }
+
+  try {
+    const supabase = getSupabase();
+    const row: Record<string, unknown> = {
+      strava_id: body.strava_id,
+      display_name: displayName,
+      icon_url: iconUrl,
+      strava_access_token: encryptedAccess,
+      strava_refresh_token: encryptedRefresh,
+      strava_token_expires_at: expiresAt,
+      updated_at: new Date().toISOString(),
+    };
+
+    const { error } = await supabase.from("users").upsert(row, { onConflict: "strava_id" });
+
+    if (error) {
+      console.error("[webhook-server] users/sync upsert error:", error);
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: error.message }));
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[webhook-server] users/sync error:", err);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: msg }));
+  }
+}
+
 async function handlePost(
   req: IncomingMessage,
   res: ServerResponse
 ): Promise<void> {
-  const body = await parseBody(req);
+  const body = await parseWebhookBody(req);
   if (!body) {
     res.writeHead(400, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Missing or invalid object_id, owner_id" }));
@@ -159,14 +226,24 @@ function notFound(res: ServerResponse): void {
   res.end();
 }
 
+function getPath(url: string | undefined): string {
+  if (!url) return "";
+  const i = url.indexOf("?");
+  return i === -1 ? url : url.slice(0, i);
+}
+
 const server = createServer(async (req, res) => {
-  if (req.method === "POST" && req.url === PATH) {
+  const path = getPath(req.url);
+  if (req.method === "POST" && path === PATH_WEBHOOK) {
     await handlePost(req, res);
+  } else if (req.method === "POST" && path === PATH_USERS_SYNC) {
+    await handleUsersSync(req, res);
   } else {
     notFound(res);
   }
 });
 
 server.listen(PORT, () => {
-  console.log(`Webhook server listening on http://localhost:${PORT}${PATH}`);
+  console.log(`Webhook server listening on http://localhost:${PORT}${PATH_WEBHOOK}`);
+  console.log(`Users sync endpoint: http://localhost:${PORT}${PATH_USERS_SYNC}`);
 });

--- a/backend-api/src/webhook-server.ts
+++ b/backend-api/src/webhook-server.ts
@@ -13,6 +13,8 @@ import {
   createDefaultDeps,
 } from "./services/strava-webhook.js";
 import { decryptStravaToken, encryptStravaToken } from "./utils/token-crypto.js";
+import { createGroup, joinGroup } from "./bff/groups.js";
+import { runUsersSync, type UsersSyncBody } from "./bff/users-sync.js";
 
 function loadEnvFromCwd(): void {
   const cwd = process.cwd();
@@ -40,6 +42,8 @@ loadEnvFromCwd();
 const PORT = Number(process.env.PORT) || 3001;
 const PATH_WEBHOOK = "/webhook/activity";
 const PATH_USERS_SYNC = "/users/sync";
+const PATH_GROUPS = "/groups";
+const PATH_GROUPS_JOIN = "/groups/join";
 
 function getSupabase() {
   const url =
@@ -81,63 +85,86 @@ function parseWebhookBody(req: IncomingMessage): Promise<{ object_id: number; ow
   });
 }
 
-/** POST /users/sync のリクエストボディ */
-interface UsersSyncBody {
-  strava_id: number;
-  access_token: string;
-  refresh_token: string;
-  display_name?: string;
-  profile_image_url?: string | null;
-  icon_url?: string | null;
-  strava_token_expires_at?: string | null;
-}
-
 async function handleUsersSync(req: IncomingMessage, res: ServerResponse): Promise<void> {
   const body = await parseJsonBody<UsersSyncBody>(req);
-  if (!body || typeof body.strava_id !== "number" || typeof body.access_token !== "string" || typeof body.refresh_token !== "string") {
+  if (!body) {
     res.writeHead(400, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: "Missing or invalid strava_id, access_token, refresh_token" }));
+    res.end(JSON.stringify({ error: "Invalid JSON body" }));
     return;
   }
-
-  const displayName = typeof body.display_name === "string" && body.display_name.trim() ? body.display_name.trim() : `User ${body.strava_id}`;
-  const iconUrl = body.profile_image_url ?? body.icon_url ?? null;
-  const expiresAt = typeof body.strava_token_expires_at === "string" && body.strava_token_expires_at ? body.strava_token_expires_at : null;
-
-  const encryptedAccess = encryptStravaToken(body.access_token);
-  const encryptedRefresh = encryptStravaToken(body.refresh_token);
-  if (!encryptedAccess || !encryptedRefresh) {
-    console.error("[webhook-server] users/sync: token encryption failed (STRAVA_TOKEN_ENCRYPTION_KEY required)");
-    res.writeHead(500, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: "Token encryption failed" }));
-    return;
-  }
-
   try {
-    const supabase = getSupabase();
-    const row: Record<string, unknown> = {
-      strava_id: body.strava_id,
-      display_name: displayName,
-      icon_url: iconUrl,
-      strava_access_token: encryptedAccess,
-      strava_refresh_token: encryptedRefresh,
-      strava_token_expires_at: expiresAt,
-      updated_at: new Date().toISOString(),
-    };
-
-    const { error } = await supabase.from("users").upsert(row, { onConflict: "strava_id" });
-
-    if (error) {
-      console.error("[webhook-server] users/sync upsert error:", error);
-      res.writeHead(500, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: error.message }));
+    const result = await runUsersSync(getSupabase(), body, encryptStravaToken);
+    if (result.ok) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
       return;
     }
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ ok: true }));
+    res.writeHead(result.statusCode, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: result.error }));
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error("[webhook-server] users/sync error:", err);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: msg }));
+  }
+}
+
+async function handleGroupsCreate(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await parseJsonBody<{ name?: string; user_id?: string }>(req);
+  if (!body) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Invalid JSON body" }));
+    return;
+  }
+  try {
+    const result = await createGroup(getSupabase(), {
+      name: body.name ?? "",
+      user_id: body.user_id ?? "",
+    });
+    if (result.ok) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          ok: true,
+          group_id: result.group_id,
+          name: result.name,
+          invite_code: result.invite_code,
+        })
+      );
+      return;
+    }
+    res.writeHead(result.statusCode, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: result.error }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[webhook-server] groups create error:", err);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: msg }));
+  }
+}
+
+async function handleGroupsJoin(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await parseJsonBody<{ invite_code?: string; user_id?: string }>(req);
+  if (!body) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Invalid JSON body" }));
+    return;
+  }
+  try {
+    const result = await joinGroup(getSupabase(), {
+      invite_code: body.invite_code ?? "",
+      user_id: body.user_id ?? "",
+    });
+    if (result.ok) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, group_id: result.group_id }));
+      return;
+    }
+    res.writeHead(result.statusCode, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: result.error }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[webhook-server] groups join error:", err);
     res.writeHead(500, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: msg }));
   }
@@ -238,6 +265,10 @@ const server = createServer(async (req, res) => {
     await handlePost(req, res);
   } else if (req.method === "POST" && path === PATH_USERS_SYNC) {
     await handleUsersSync(req, res);
+  } else if (req.method === "POST" && path === PATH_GROUPS) {
+    await handleGroupsCreate(req, res);
+  } else if (req.method === "POST" && path === PATH_GROUPS_JOIN) {
+    await handleGroupsJoin(req, res);
   } else {
     notFound(res);
   }
@@ -245,5 +276,6 @@ const server = createServer(async (req, res) => {
 
 server.listen(PORT, () => {
   console.log(`Webhook server listening on http://localhost:${PORT}${PATH_WEBHOOK}`);
-  console.log(`Users sync endpoint: http://localhost:${PORT}${PATH_USERS_SYNC}`);
+  console.log(`Users sync: http://localhost:${PORT}${PATH_USERS_SYNC}`);
+  console.log(`Groups: http://localhost:${PORT}${PATH_GROUPS}, http://localhost:${PORT}${PATH_GROUPS_JOIN}`);
 });


### PR DESCRIPTION
## 概要 (Context)

BFF（Backend For Frontend）パターン移行の一環として、フロントエンドが直接行っていたグループ作成・参加処理をバックエンドに寄せ、既存の `POST /users/sync` とあわせてテスト・README を整備する。

## 対応背景

- グループ作成（`POST /api/groups`）とグループ参加（`POST /api/groups/join`）をクライアントの Next.js API Route から、backend-api の BFF エンドポイントへ移行するため。
- `.cursorrules` に従い、BFF ロジックに対応するテストコードと backend-api の README 更新を同時に行うため。

## 変更内容 (Changes)

- `backend-api/src/bff/groups.ts` を新規追加。招待コード自動生成（リトライ最大5回）と `createGroup` / `joinGroup` を実装。
- `backend-api/src/bff/users-sync.ts` を新規追加。`runUsersSync` にユーザー同期ロジックを切り出し、`webhook-server.ts` の `handleUsersSync` から利用。
- `backend-api/src/webhook-server.ts` に `POST /groups` と `POST /groups/join` を追加し、上記 BFF モジュールを呼び出すように変更。
- `backend-api/src/bff/groups.test.ts` を新規追加（createGroup 5 件・joinGroup 6 件のテスト）。
- `backend-api/src/bff/users-sync.test.ts` を新規追加（runUsersSync 5 件のテスト）。
- `backend-api/README.md` に BFF エンドポイントの仕様（`/users/sync`・`/groups`・`/groups/join` のリクエスト/レスポンス）を追記。

## 動作確認手順 (How to Test)

1. `backend-api` で `npm run test` を実行し、全テストがパスすることを確認する。
2. `npm run build` の後に `npm run webhook-server` でサーバーを起動し、`POST /groups`（body: `{ "name": "テスト", "user_id": "<有効なUUID>" }`）で 200 と `group_id` / `invite_code` が返ることを確認する。
3. 同様に `POST /groups/join`（body: `{ "invite_code": "<上記で得たコード>", "user_id": "<別ユーザーUUID>" }`）で 200 と `group_id` が返ることを確認する。

## 影響範囲と懸念事項 (Impact & Concerns)

- フロントエンドは未変更。今後クライアントの `POST /api/groups` および `POST /api/groups/join` を、本 backend-api の `POST /groups`・`POST /groups/join` を呼び出すように変更する PR で切り替える想定。
- 既存の `POST /users/sync` の挙動は、ロジックを `runUsersSync` に移したのみで変更なし。

## チェックリスト (Checklist)

- [x] 必要なテストコードを追加・更新し、すべてパスしている
- [ ] VercelのPreview環境でUIの表示崩れがないか確認できる状態にある
- [ ] 環境変数（`.env`）の追加や変更が必要な場合、その旨を記載している
- [ ] 動作画面に変更がある場合、変更前後のスクリーンショットを載せている