### PR TITLE
Add BFF endpoints for user sync and group management; token encryption and RLS migration

### DIFF
--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -24,3 +24,44 @@ npm install
 - **起動:** `npm run build` の後に `npm run webhook-server`（`backend-api` ディレクトリで実行すること）。
 - デフォルトで `http://localhost:3001/webhook/activity` で待ち受け（`PORT` 環境変数で変更可）。
 - **環境変数:** 起動時に **backend-api 直下の `.env.local` または `.env`** を自動読み込みする。`SUPABASE_URL`（または `NEXT_PUBLIC_SUPABASE_URL`）と `SUPABASE_SERVICE_ROLE_KEY` が必須。client で Strava トークンを暗号化して保存している場合は、復号用に **`STRAVA_TOKEN_ENCRYPTION_KEY`** を client と同一の値で設定する（未設定なら DB の平文トークンをそのまま使用）。`backend-api/.env.example` をコピーして `backend-api/.env.local` を作成し、値を設定する。
+
+## BFF エンドポイント（Backend For Frontend）
+
+フロントエンドからの直接 DB 操作を廃止し、バックエンド経由で行うための API。いずれも `POST`、Content-Type: `application/json`。同一の Webhook サーバー（`npm run webhook-server`）で待ち受ける。
+
+### POST /users/sync
+
+ユーザー情報（Strava トークン含む）を受け取り、トークンを暗号化して `users` テーブルに upsert する。
+
+- **リクエストボディ（JSON）**
+  - `strava_id` (number, 必須): Strava の Athlete ID
+  - `access_token` (string, 必須): Strava アクセストークン（平文。サーバー側で暗号化して保存）
+  - `refresh_token` (string, 必須): Strava リフレッシュトークン（平文。サーバー側で暗号化して保存）
+  - `display_name` (string, 任意): 表示名。省略時は `User {strava_id}`
+  - `profile_image_url` / `icon_url` (string | null, 任意): アイコン URL
+  - `strava_token_expires_at` (string | null, 任意): トークン有効期限（ISO 8601）
+- **レスポンス**
+  - 成功: `200` + `{ "ok": true }`
+  - 失敗: `400`（必須項目不足・不正）/ `500`（暗号化失敗・DB エラー） + `{ "error": "メッセージ" }`
+
+### POST /groups
+
+グループ名を受け取り、招待コードを自動生成（重複時はリトライ）して `groups` と `group_members` に insert する。
+
+- **リクエストボディ（JSON）**
+  - `name` (string, 必須): グループ名
+  - `user_id` (string, 必須): 作成者ユーザーの UUID（フロントのセッション等で取得した id）
+- **レスポンス**
+  - 成功: `200` + `{ "ok": true, "group_id": "uuid", "name": "グループ名", "invite_code": "8文字16進" }`
+  - 失敗: `400`（name 空・user_id 不正）/ `409`（招待コード衝突がリトライ上限超過）/ `500` + `{ "error": "メッセージ" }`
+
+### POST /groups/join
+
+招待コードを受け取り、対象グループを検索して `group_members` に insert する。
+
+- **リクエストボディ（JSON）**
+  - `invite_code` (string, 必須): 招待コード（8 文字 16 進）
+  - `user_id` (string, 必須): 参加するユーザーの UUID
+- **レスポンス**
+  - 成功: `200` + `{ "ok": true, "group_id": "uuid" }`
+  - 失敗: `400`（招待コード空・user_id 不正）/ `404`（招待コードに一致するグループなし）/ `409`（既に参加済み）/ `500` + `{ "error": "メッセージ" }`

--- a/backend-api/src/bff/groups.test.ts
+++ b/backend-api/src/bff/groups.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi } from "vitest";
+import { createGroup, joinGroup } from "./groups.js";
+
+const validUserId = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("createGroup", () => {
+  it("name が空の場合は 400", async () => {
+    const mockFrom = vi.fn(() => ({}));
+    const supabase = { from: mockFrom };
+    const result = await createGroup(supabase as never, { name: "", user_id: validUserId });
+    expect(result).toEqual({ ok: false, statusCode: 400, error: "Missing or invalid name" });
+  });
+
+  it("user_id が不正な場合は 400", async () => {
+    const mockFrom = vi.fn(() => ({}));
+    const supabase = { from: mockFrom };
+    const result = await createGroup(supabase as never, { name: "My Group", user_id: "not-a-uuid" });
+    expect(result).toEqual({ ok: false, statusCode: 400, error: "Missing or invalid user_id" });
+  });
+
+  it("groups insert 成功後に group_members insert が失敗した場合は 500", async () => {
+    const mockGroupsInsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { id: "g1", name: "My Group", invite_code: "abc12345" },
+          error: null,
+        }),
+      }),
+    });
+    const mockMembersInsert = vi.fn().mockResolvedValue({ error: { message: "FK violation" } });
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups") return { insert: mockGroupsInsert };
+      if (table === "group_members") return { insert: mockMembersInsert };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await createGroup(supabase as never, { name: "My Group", user_id: validUserId });
+    expect(result).toEqual({ ok: false, statusCode: 500, error: "FK violation" });
+  });
+
+  it("groups insert 成功・group_members 成功で ok: true と group_id, name, invite_code を返す", async () => {
+    const mockGroupsInsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { id: "g1", name: "My Group", invite_code: "deadbeef" },
+          error: null,
+        }),
+      }),
+    });
+    const mockMembersInsert = vi.fn().mockResolvedValue({ error: null });
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups") return { insert: mockGroupsInsert };
+      if (table === "group_members") return { insert: mockMembersInsert };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await createGroup(supabase as never, { name: "My Group", user_id: validUserId });
+    expect(result).toEqual({
+      ok: true,
+      group_id: "g1",
+      name: "My Group",
+      invite_code: "deadbeef",
+    });
+    expect(mockMembersInsert).toHaveBeenCalledWith({ group_id: "g1", user_id: validUserId });
+  });
+
+  it("groups insert が 23505 の場合はリトライし、最終的に全て衝突なら 409", async () => {
+    const mockGroupsInsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: null,
+          error: { code: "23505" },
+        }),
+      }),
+    });
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups") return { insert: mockGroupsInsert };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await createGroup(supabase as never, { name: "My Group", user_id: validUserId });
+    expect(result).toEqual({
+      ok: false,
+      statusCode: 409,
+      error: "Invite code conflict after retries",
+    });
+    expect(mockGroupsInsert).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe("joinGroup", () => {
+  it("invite_code が空の場合は 400", async () => {
+    const mockFrom = vi.fn(() => ({}));
+    const supabase = { from: mockFrom };
+    const result = await joinGroup(supabase as never, { invite_code: "", user_id: validUserId });
+    expect(result).toEqual({ ok: false, statusCode: 400, error: "Missing or invalid invite_code" });
+  });
+
+  it("user_id が不正な場合は 400", async () => {
+    const mockFrom = vi.fn(() => ({}));
+    const supabase = { from: mockFrom };
+    const result = await joinGroup(supabase as never, { invite_code: "abc12345", user_id: "x" });
+    expect(result).toEqual({ ok: false, statusCode: 400, error: "Missing or invalid user_id" });
+  });
+
+  it("招待コードに一致するグループが無い場合は 404", async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups")
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await joinGroup(supabase as never, {
+      invite_code: "nonexistent",
+      user_id: validUserId,
+    });
+    expect(result).toEqual({ ok: false, statusCode: 404, error: "Group not found" });
+  });
+
+  it("グループ取得エラー時は 500", async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups")
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: "DB error" } }),
+            }),
+          }),
+        };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await joinGroup(supabase as never, {
+      invite_code: "abc12345",
+      user_id: validUserId,
+    });
+    expect(result).toEqual({ ok: false, statusCode: 500, error: "DB error" });
+  });
+
+  it("既に参加済み（23505）の場合は 409", async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups")
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { id: "g1" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      if (table === "group_members")
+        return {
+          insert: vi.fn().mockResolvedValue({ error: { code: "23505" } }),
+        };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await joinGroup(supabase as never, {
+      invite_code: "abc12345",
+      user_id: validUserId,
+    });
+    expect(result).toEqual({ ok: false, statusCode: 409, error: "Already a member" });
+  });
+
+  it("参加成功時は ok: true と group_id を返す", async () => {
+    const mockMembersInsert = vi.fn().mockResolvedValue({ error: null });
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "groups")
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { id: "g1" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      if (table === "group_members") return { insert: mockMembersInsert };
+      return {};
+    });
+    const supabase = { from: mockFrom };
+
+    const result = await joinGroup(supabase as never, {
+      invite_code: "abc12345",
+      user_id: validUserId,
+    });
+    expect(result).toEqual({ ok: true, group_id: "g1" });
+    expect(mockMembersInsert).toHaveBeenCalledWith({ group_id: "g1", user_id: validUserId });
+  });
+});

--- a/backend-api/src/bff/groups.ts
+++ b/backend-api/src/bff/groups.ts
@@ -1,0 +1,126 @@
+/**
+ * BFF: グループ作成・参加ロジック（招待コード生成リトライ含む）
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { randomBytes } from "node:crypto";
+
+const INVITE_CODE_BYTES = 4;
+const MAX_RETRIES = 5;
+
+function generateInviteCode(): string {
+  return randomBytes(INVITE_CODE_BYTES).toString("hex");
+}
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+function isValidUUID(s: string): boolean {
+  return typeof s === "string" && UUID_REGEX.test(s);
+}
+
+export interface CreateGroupBody {
+  name: string;
+  user_id: string;
+}
+
+export type CreateGroupResult =
+  | { ok: true; group_id: string; name: string; invite_code: string }
+  | { ok: false; statusCode: number; error: string };
+
+export async function createGroup(
+  supabase: SupabaseClient,
+  body: CreateGroupBody
+): Promise<CreateGroupResult> {
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  if (!name) {
+    return { ok: false, statusCode: 400, error: "Missing or invalid name" };
+  }
+  if (!isValidUUID(body.user_id)) {
+    return { ok: false, statusCode: 400, error: "Missing or invalid user_id" };
+  }
+
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const inviteCode = generateInviteCode();
+    const { data: newGroup, error: insertGroupError } = await supabase
+      .from("groups")
+      .insert({ name, invite_code: inviteCode })
+      .select("id, name, invite_code")
+      .single();
+
+    if (!insertGroupError) {
+      const { error: insertMemberError } = await supabase
+        .from("group_members")
+        .insert({ group_id: newGroup.id, user_id: body.user_id });
+
+      if (insertMemberError) {
+        return { ok: false, statusCode: 500, error: insertMemberError.message };
+      }
+      return {
+        ok: true,
+        group_id: newGroup.id,
+        name: newGroup.name,
+        invite_code: newGroup.invite_code,
+      };
+    }
+
+    if (insertGroupError.code === "23505") {
+      lastError = insertGroupError;
+      continue;
+    }
+    return { ok: false, statusCode: 500, error: insertGroupError.message };
+  }
+
+  return {
+    ok: false,
+    statusCode: 409,
+    error: "Invite code conflict after retries",
+  };
+}
+
+export interface JoinGroupBody {
+  invite_code: string;
+  user_id: string;
+}
+
+export type JoinGroupResult =
+  | { ok: true; group_id: string }
+  | { ok: false; statusCode: number; error: string };
+
+export async function joinGroup(
+  supabase: SupabaseClient,
+  body: JoinGroupBody
+): Promise<JoinGroupResult> {
+  const inviteCode =
+    typeof body.invite_code === "string" ? body.invite_code.trim() : "";
+  if (!inviteCode) {
+    return { ok: false, statusCode: 400, error: "Missing or invalid invite_code" };
+  }
+  if (!isValidUUID(body.user_id)) {
+    return { ok: false, statusCode: 400, error: "Missing or invalid user_id" };
+  }
+
+  const { data: group, error: groupError } = await supabase
+    .from("groups")
+    .select("id")
+    .eq("invite_code", inviteCode)
+    .maybeSingle();
+
+  if (groupError) {
+    return { ok: false, statusCode: 500, error: groupError.message };
+  }
+  if (!group?.id) {
+    return { ok: false, statusCode: 404, error: "Group not found" };
+  }
+
+  const { error: insertError } = await supabase.from("group_members").insert({
+    group_id: group.id,
+    user_id: body.user_id,
+  });
+
+  if (insertError) {
+    if (insertError.code === "23505") {
+      return { ok: false, statusCode: 409, error: "Already a member" };
+    }
+    return { ok: false, statusCode: 500, error: insertError.message };
+  }
+  return { ok: true, group_id: group.id };
+}

--- a/backend-api/src/bff/users-sync.test.ts
+++ b/backend-api/src/bff/users-sync.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from "vitest";
+import { runUsersSync, type UsersSyncBody } from "./users-sync.js";
+
+const validBody: UsersSyncBody = {
+  strava_id: 12345,
+  access_token: "access",
+  refresh_token: "refresh",
+  display_name: "Test User",
+  profile_image_url: "https://example.com/icon.png",
+  strava_token_expires_at: "2025-12-31T00:00:00Z",
+};
+
+describe("runUsersSync", () => {
+  it("必須項目が欠けている場合は 400", async () => {
+    const encrypt = vi.fn((s: string) => `enc:${s}`);
+    const mockSingle = vi.fn().mockResolvedValue({ data: { id: "user-1" }, error: null });
+    const mockSelect = vi.fn(() => ({ single: mockSingle }));
+    const mockUpsert = vi.fn(() => ({ select: mockSelect }));
+    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
+    const supabase = { from: mockFrom };
+
+    const missingStravaId = { ...validBody, strava_id: undefined } as unknown as UsersSyncBody;
+    expect(await runUsersSync(supabase as never, missingStravaId, encrypt)).toEqual({
+      ok: false,
+      statusCode: 400,
+      error: "Missing or invalid strava_id, access_token, refresh_token",
+    });
+
+    const missingAccessToken = { ...validBody, access_token: undefined } as unknown as UsersSyncBody;
+    expect(await runUsersSync(supabase as never, missingAccessToken, encrypt)).toEqual({
+      ok: false,
+      statusCode: 400,
+      error: "Missing or invalid strava_id, access_token, refresh_token",
+    });
+  });
+
+  it("暗号化が null を返す場合は 500", async () => {
+    const encrypt = vi.fn(() => null);
+    const mockSingle = vi.fn().mockResolvedValue({ data: { id: "user-1" }, error: null });
+    const mockSelect = vi.fn(() => ({ single: mockSingle }));
+    const mockUpsert = vi.fn(() => ({ select: mockSelect }));
+    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
+    const supabase = { from: mockFrom };
+
+    const result = await runUsersSync(supabase as never, validBody, encrypt);
+    expect(result).toEqual({ ok: false, statusCode: 500, error: "Token encryption failed" });
+  });
+
+  it("upsert 成功時は ok: true と id を返す", async () => {
+    const encrypt = vi.fn((s: string) => `enc:${s}`);
+    const mockSingle = vi.fn().mockResolvedValue({ data: { id: "user-1" }, error: null });
+    const mockSelect = vi.fn(() => ({ single: mockSingle }));
+    const mockUpsert = vi.fn(() => ({ select: mockSelect }));
+    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
+    const supabase = { from: mockFrom };
+
+    const result = await runUsersSync(supabase as never, validBody, encrypt);
+    expect(result).toEqual({ ok: true, id: "user-1" });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        strava_id: 12345,
+        display_name: "Test User",
+        icon_url: "https://example.com/icon.png",
+        strava_access_token: "enc:access",
+        strava_refresh_token: "enc:refresh",
+        strava_token_expires_at: "2025-12-31T00:00:00Z",
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it("display_name が空の場合は User {strava_id} になる", async () => {
+    const encrypt = vi.fn((s: string) => `enc:${s}`);
+    const mockSingle = vi.fn().mockResolvedValue({ data: { id: "user-1" }, error: null });
+    const mockSelect = vi.fn(() => ({ single: mockSingle }));
+    const mockUpsert = vi.fn(() => ({ select: mockSelect }));
+    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
+    const supabase = { from: mockFrom };
+    const body = { ...validBody, display_name: "", profile_image_url: null };
+
+    await runUsersSync(supabase as never, body, encrypt);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ display_name: "User 12345" }),
+      expect.any(Object)
+    );
+  });
+
+  it("Supabase upsert がエラーの場合は 500", async () => {
+    const encrypt = vi.fn((s: string) => `enc:${s}`);
+    const mockSingle = vi.fn().mockResolvedValue({ data: null, error: { message: "DB error" } });
+    const mockSelect = vi.fn(() => ({ single: mockSingle }));
+    const mockUpsert = vi.fn(() => ({ select: mockSelect }));
+    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
+    const supabase = { from: mockFrom };
+
+    const result = await runUsersSync(supabase as never, validBody, encrypt);
+    expect(result).toEqual({ ok: false, statusCode: 500, error: "DB error" });
+  });
+
+  it("upsert は成功したが id が無い場合は 500", async () => {
+    const encrypt = vi.fn((s: string) => `enc:${s}`);
+    const mockSingle = vi.fn().mockResolvedValue({ data: {}, error: null });
+    const mockSelect = vi.fn(() => ({ single: mockSingle }));
+    const mockUpsert = vi.fn(() => ({ select: mockSelect }));
+    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
+    const supabase = { from: mockFrom };
+
+    const result = await runUsersSync(supabase as never, validBody, encrypt);
+    expect(result).toEqual({
+      ok: false,
+      statusCode: 500,
+      error: "users upsert succeeded but id was missing",
+    });
+  });
+});

--- a/backend-api/src/bff/users-sync.ts
+++ b/backend-api/src/bff/users-sync.ts
@@ -1,0 +1,79 @@
+/**
+ * BFF: ユーザー情報の同期（トークン暗号化して users に upsert）
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface UsersSyncBody {
+  strava_id: number;
+  access_token: string;
+  refresh_token: string;
+  display_name?: string;
+  profile_image_url?: string | null;
+  icon_url?: string | null;
+  strava_token_expires_at?: string | null;
+}
+
+export type UsersSyncResult =
+  | { ok: true; id: string }
+  | { ok: false; statusCode: number; error: string };
+
+export type EncryptFn = (plaintext: string) => string | null;
+
+export async function runUsersSync(
+  supabase: SupabaseClient,
+  body: UsersSyncBody,
+  encrypt: EncryptFn
+): Promise<UsersSyncResult> {
+  if (
+    typeof body.strava_id !== "number" ||
+    typeof body.access_token !== "string" ||
+    typeof body.refresh_token !== "string"
+  ) {
+    return {
+      ok: false,
+      statusCode: 400,
+      error: "Missing or invalid strava_id, access_token, refresh_token",
+    };
+  }
+
+  const displayName =
+    typeof body.display_name === "string" && body.display_name.trim()
+      ? body.display_name.trim()
+      : `User ${body.strava_id}`;
+  const iconUrl = body.profile_image_url ?? body.icon_url ?? null;
+  const expiresAt =
+    typeof body.strava_token_expires_at === "string" &&
+    body.strava_token_expires_at
+      ? body.strava_token_expires_at
+      : null;
+
+  const encryptedAccess = encrypt(body.access_token);
+  const encryptedRefresh = encrypt(body.refresh_token);
+  if (!encryptedAccess || !encryptedRefresh) {
+    return { ok: false, statusCode: 500, error: "Token encryption failed" };
+  }
+
+  const row: Record<string, unknown> = {
+    strava_id: body.strava_id,
+    display_name: displayName,
+    icon_url: iconUrl,
+    strava_access_token: encryptedAccess,
+    strava_refresh_token: encryptedRefresh,
+    strava_token_expires_at: expiresAt,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { data, error } = await supabase
+    .from("users")
+    .upsert(row, { onConflict: "strava_id" })
+    .select("id")
+    .single();
+
+  if (error) {
+    return { ok: false, statusCode: 500, error: error.message };
+  }
+  if (!data?.id || typeof data.id !== "string") {
+    return { ok: false, statusCode: 500, error: "users upsert succeeded but id was missing" };
+  }
+  return { ok: true, id: data.id };
+}

--- a/backend-api/src/utils/token-crypto.ts
+++ b/backend-api/src/utils/token-crypto.ts
@@ -1,8 +1,8 @@
 /**
- * Strava トークンの復号（client で暗号化した値を DB から読み取り時に復号）
- * client の lib/strava-token-crypto と同じ AES-256-GCM 形式。
+ * Strava トークンの暗号化・復号（client の lib/strava-token-crypto と同じ AES-256-GCM 形式）
+ * BFF ではバックエンドでトークンを暗号化して DB に保存する。
  */
-import { createDecipheriv } from "node:crypto";
+import { randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
 
 const ALG = "aes-256-gcm";
 const IV_LEN = 12;
@@ -14,6 +14,23 @@ function getKey(): Buffer | null {
   if (!raw || typeof raw !== "string") return null;
   const key = Buffer.from(raw, "base64");
   return key.length === KEY_LEN ? key : null;
+}
+
+/**
+ * トークンを暗号化し、base64(iv + ciphertext + authTag) を返す。
+ * STRAVA_TOKEN_ENCRYPTION_KEY が未設定の場合は null を返す。
+ */
+export function encryptStravaToken(plaintext: string): string | null {
+  const key = getKey();
+  if (!key) return null;
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALG, key, iv);
+  const enc = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, enc, tag]).toString("base64");
 }
 
 /**

--- a/backend-api/src/webhook-server.ts
+++ b/backend-api/src/webhook-server.ts
@@ -12,7 +12,9 @@ import {
   processActivityDelete,
   createDefaultDeps,
 } from "./services/strava-webhook.js";
-import { decryptStravaToken } from "./utils/token-crypto.js";
+import { decryptStravaToken, encryptStravaToken } from "./utils/token-crypto.js";
+import { createGroup, joinGroup } from "./bff/groups.js";
+import { runUsersSync, type UsersSyncBody } from "./bff/users-sync.js";
 
 function loadEnvFromCwd(): void {
   const cwd = process.cwd();
@@ -38,7 +40,10 @@ function loadEnvFromCwd(): void {
 loadEnvFromCwd();
 
 const PORT = Number(process.env.PORT) || 3001;
-const PATH = "/webhook/activity";
+const PATH_WEBHOOK = "/webhook/activity";
+const PATH_USERS_SYNC = "/users/sync";
+const PATH_GROUPS = "/groups";
+const PATH_GROUPS_JOIN = "/groups/join";
 
 function getSupabase() {
   const url =
@@ -47,7 +52,7 @@ function getSupabase() {
   return createClient(url, key);
 }
 
-function parseBody(req: IncomingMessage): Promise<{ object_id: number; owner_id: number; action?: string } | null> {
+function parseJsonBody<T>(req: IncomingMessage): Promise<T | null> {
   return new Promise((resolve) => {
     let data = "";
     req.on("data", (chunk) => {
@@ -55,20 +60,7 @@ function parseBody(req: IncomingMessage): Promise<{ object_id: number; owner_id:
     });
     req.on("end", () => {
       try {
-        const body = JSON.parse(data) as unknown;
-        if (
-          body &&
-          typeof (body as { object_id?: number }).object_id === "number" &&
-          typeof (body as { owner_id?: number }).owner_id === "number"
-        ) {
-          resolve({
-            object_id: (body as { object_id: number }).object_id,
-            owner_id: (body as { owner_id: number }).owner_id,
-            action: typeof (body as { action?: string }).action === "string" ? (body as { action: string }).action : undefined,
-          });
-        } else {
-          resolve(null);
-        }
+        resolve(data ? (JSON.parse(data) as T) : null);
       } catch {
         resolve(null);
       }
@@ -76,11 +68,113 @@ function parseBody(req: IncomingMessage): Promise<{ object_id: number; owner_id:
   });
 }
 
+function parseWebhookBody(req: IncomingMessage): Promise<{ object_id: number; owner_id: number; action?: string } | null> {
+  return parseJsonBody(req).then((body) => {
+    if (
+      body &&
+      typeof (body as { object_id?: number }).object_id === "number" &&
+      typeof (body as { owner_id?: number }).owner_id === "number"
+    ) {
+      return {
+        object_id: (body as { object_id: number }).object_id,
+        owner_id: (body as { owner_id: number }).owner_id,
+        action: typeof (body as { action?: string }).action === "string" ? (body as { action: string }).action : undefined,
+      };
+    }
+    return null;
+  });
+}
+
+async function handleUsersSync(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await parseJsonBody<UsersSyncBody>(req);
+  if (!body) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Invalid JSON body" }));
+    return;
+  }
+  try {
+    const result = await runUsersSync(getSupabase(), body, encryptStravaToken);
+    if (result.ok) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, id: result.id }));
+      return;
+    }
+    res.writeHead(result.statusCode, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: result.error }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[webhook-server] users/sync error:", err);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: msg }));
+  }
+}
+
+async function handleGroupsCreate(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await parseJsonBody<{ name?: string; user_id?: string }>(req);
+  if (!body) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Invalid JSON body" }));
+    return;
+  }
+  try {
+    const result = await createGroup(getSupabase(), {
+      name: body.name ?? "",
+      user_id: body.user_id ?? "",
+    });
+    if (result.ok) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          ok: true,
+          group_id: result.group_id,
+          name: result.name,
+          invite_code: result.invite_code,
+        })
+      );
+      return;
+    }
+    res.writeHead(result.statusCode, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: result.error }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[webhook-server] groups create error:", err);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: msg }));
+  }
+}
+
+async function handleGroupsJoin(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await parseJsonBody<{ invite_code?: string; user_id?: string }>(req);
+  if (!body) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Invalid JSON body" }));
+    return;
+  }
+  try {
+    const result = await joinGroup(getSupabase(), {
+      invite_code: body.invite_code ?? "",
+      user_id: body.user_id ?? "",
+    });
+    if (result.ok) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, group_id: result.group_id }));
+      return;
+    }
+    res.writeHead(result.statusCode, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: result.error }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[webhook-server] groups join error:", err);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: msg }));
+  }
+}
+
 async function handlePost(
   req: IncomingMessage,
   res: ServerResponse
 ): Promise<void> {
-  const body = await parseBody(req);
+  const body = await parseWebhookBody(req);
   if (!body) {
     res.writeHead(400, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Missing or invalid object_id, owner_id" }));
@@ -159,14 +253,29 @@ function notFound(res: ServerResponse): void {
   res.end();
 }
 
+function getPath(url: string | undefined): string {
+  if (!url) return "";
+  const i = url.indexOf("?");
+  return i === -1 ? url : url.slice(0, i);
+}
+
 const server = createServer(async (req, res) => {
-  if (req.method === "POST" && req.url === PATH) {
+  const path = getPath(req.url);
+  if (req.method === "POST" && path === PATH_WEBHOOK) {
     await handlePost(req, res);
+  } else if (req.method === "POST" && path === PATH_USERS_SYNC) {
+    await handleUsersSync(req, res);
+  } else if (req.method === "POST" && path === PATH_GROUPS) {
+    await handleGroupsCreate(req, res);
+  } else if (req.method === "POST" && path === PATH_GROUPS_JOIN) {
+    await handleGroupsJoin(req, res);
   } else {
     notFound(res);
   }
 });
 
 server.listen(PORT, () => {
-  console.log(`Webhook server listening on http://localhost:${PORT}${PATH}`);
+  console.log(`Webhook server listening on http://localhost:${PORT}${PATH_WEBHOOK}`);
+  console.log(`Users sync: http://localhost:${PORT}${PATH_USERS_SYNC}`);
+  console.log(`Groups: http://localhost:${PORT}${PATH_GROUPS}, http://localhost:${PORT}${PATH_GROUPS_JOIN}`);
 });

--- a/client/app/api/auth/strava/callback/route.ts
+++ b/client/app/api/auth/strava/callback/route.ts
@@ -1,11 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSupabaseServer } from "@/lib/supabase";
 import {
   createSessionToken,
   getSessionCookieOptions,
   SESSION_COOKIE_NAME,
 } from "@/lib/session";
-import { encryptStravaToken } from "@/lib/strava-token-crypto";
 
 const STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token";
 
@@ -81,37 +79,53 @@ export async function GET(request: NextRequest) {
   const iconUrl = athlete.profile ?? athlete.profile_medium ?? null;
   const expiresAt = tokenData.expires_at != null ? new Date(tokenData.expires_at * 1000).toISOString() : null;
 
-  const encryptedAccess = encryptStravaToken(tokenData.access_token);
-  const encryptedRefresh = encryptStravaToken(tokenData.refresh_token);
-  if (!encryptedAccess || !encryptedRefresh) {
-    console.error("Strava token encryption failed: STRAVA_TOKEN_ENCRYPTION_KEY is required");
-    return NextResponse.redirect(`${baseRedirect}/login?error=token_encryption`);
+  const backendUrl = process.env.BACKEND_API_URL?.replace(/\/$/, "") ?? "";
+  if (!backendUrl) {
+    console.error("User sync failed: BACKEND_API_URL is not configured");
+    return NextResponse.redirect(`${baseRedirect}/login?error=config`);
   }
 
-  const supabase = getSupabaseServer();
-  const { data: user, error: upsertError } = await supabase
-    .from("users")
-    .upsert(
-      {
-        strava_id: athlete.id,
-        display_name: displayName,
-        icon_url: iconUrl,
-        strava_access_token: encryptedAccess,
-        strava_refresh_token: encryptedRefresh,
-        strava_token_expires_at: expiresAt,
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: "strava_id" }
-    )
-    .select("id")
-    .single();
+  const syncPayload = {
+    strava_id: athlete.id,
+    access_token: tokenData.access_token,
+    refresh_token: tokenData.refresh_token,
+    display_name: displayName,
+    profile_image_url: iconUrl,
+    strava_token_expires_at: expiresAt,
+  };
 
-  if (upsertError || !user?.id) {
-    console.error("Supabase users upsert error:", upsertError);
+  let syncRes: Response;
+  try {
+    syncRes = await fetch(`${backendUrl}/users/sync`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(syncPayload),
+    });
+  } catch (e) {
+    console.error("User sync request failed:", e);
     return NextResponse.redirect(`${baseRedirect}/login?error=upsert`);
   }
 
-  const token = await createSessionToken(user.id);
+  if (!syncRes.ok) {
+    const text = await syncRes.text();
+    console.error("User sync failed:", syncRes.status, text);
+    return NextResponse.redirect(`${baseRedirect}/login?error=upsert`);
+  }
+
+  let syncData: { id?: string };
+  try {
+    syncData = (await syncRes.json()) as { id?: string };
+  } catch {
+    console.error("User sync: invalid JSON response");
+    return NextResponse.redirect(`${baseRedirect}/login?error=upsert`);
+  }
+
+  if (!syncData?.id) {
+    console.error("User sync: response missing id");
+    return NextResponse.redirect(`${baseRedirect}/login?error=upsert`);
+  }
+
+  const token = await createSessionToken(syncData.id);
   const response = NextResponse.redirect(baseRedirect);
   response.cookies.set(SESSION_COOKIE_NAME, token, getSessionCookieOptions());
   return response;

--- a/client/app/api/groups/join/route.ts
+++ b/client/app/api/groups/join/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSessionUserId } from "@/lib/session";
-import { getSupabaseServer } from "@/lib/supabase";
 
 /**
  * POST /api/groups/join
- * 招待コードでグループに参加し、group_members にレコードを追加する。
- * Body: { invite_code: string }
+ * 招待コードでグループ参加をバックエンドAPI (BFF) に委譲する。
+ * Body: { invite_code: string }。BFF へは { invite_code, user_id } を送信。
  */
 export async function POST(request: NextRequest) {
   const userId = await getSessionUserId();
@@ -35,47 +34,41 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const supabase = getSupabaseServer();
-
-  const { data: group, error: groupError } = await supabase
-    .from("groups")
-    .select("id")
-    .eq("invite_code", inviteCode)
-    .maybeSingle();
-
-  if (groupError) {
-    console.error("groups fetch error:", groupError);
+  const backendUrl = process.env.BACKEND_API_URL?.replace(/\/$/, "") ?? "";
+  if (!backendUrl) {
+    console.error("POST /api/groups/join: BACKEND_API_URL is not configured");
     return NextResponse.json(
-      { error: "Internal Server Error", message: "グループの取得に失敗しました" },
+      { error: "Internal Server Error", message: "サーバー設定エラーです" },
       { status: 500 }
     );
   }
 
-  if (!group?.id) {
-    return NextResponse.json(
-      { error: "Not Found", message: "招待コードに一致するグループがありません" },
-      { status: 404 }
-    );
-  }
+  try {
+    const res = await fetch(`${backendUrl}/groups/join`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ invite_code: inviteCode, user_id: userId }),
+    });
 
-  const { error: insertError } = await supabase.from("group_members").insert({
-    group_id: group.id,
-    user_id: userId,
-  });
+    const data = await res.json().catch(() => ({}));
 
-  if (insertError) {
-    if (insertError.code === "23505") {
+    if (!res.ok) {
+      const message =
+        typeof data?.message === "string"
+          ? data.message
+          : "参加処理に失敗しました";
       return NextResponse.json(
-        { error: "Conflict", message: "すでにこのグループに参加しています" },
-        { status: 409 }
+        { error: data?.error ?? "Internal Server Error", message },
+        { status: res.status }
       );
     }
-    console.error("group_members insert error:", insertError);
+
+    return NextResponse.json(data);
+  } catch (e) {
+    console.error("POST /api/groups/join: BFF request failed:", e);
     return NextResponse.json(
       { error: "Internal Server Error", message: "参加処理に失敗しました" },
       { status: 500 }
     );
   }
-
-  return NextResponse.json({ ok: true, group_id: group.id });
 }

--- a/client/app/api/groups/route.ts
+++ b/client/app/api/groups/route.ts
@@ -1,19 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { randomBytes } from "crypto";
 import { getSessionUserId } from "@/lib/session";
-import { getSupabaseServer } from "@/lib/supabase";
-
-const INVITE_CODE_BYTES = 4; // 8 hex chars
-const MAX_RETRIES = 5;
-
-function generateInviteCode(): string {
-  return randomBytes(INVITE_CODE_BYTES).toString("hex");
-}
 
 /**
  * POST /api/groups
- * グループを新規作成し、作成者を group_members に追加する。
- * 招待コードはサーバーで自動生成する（Body: { name: string } のみ）。
+ * グループ新規作成をバックエンドAPI (BFF) に委譲する。
+ * Body: { name: string } のみ。BFF へは { name, user_id } を送信。
  */
 export async function POST(request: NextRequest) {
   const userId = await getSessionUserId();
@@ -43,52 +34,41 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const supabase = getSupabaseServer();
-  let lastError: unknown = null;
+  const backendUrl = process.env.BACKEND_API_URL?.replace(/\/$/, "") ?? "";
+  if (!backendUrl) {
+    console.error("POST /api/groups: BACKEND_API_URL is not configured");
+    return NextResponse.json(
+      { error: "Internal Server Error", message: "サーバー設定エラーです" },
+      { status: 500 }
+    );
+  }
 
-  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    const inviteCode = generateInviteCode();
-    const { data: newGroup, error: insertGroupError } = await supabase
-      .from("groups")
-      .insert({ name, invite_code: inviteCode })
-      .select("id, name, invite_code")
-      .single();
+  try {
+    const res = await fetch(`${backendUrl}/groups`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, user_id: userId }),
+    });
 
-    if (!insertGroupError) {
-      const { error: insertMemberError } = await supabase
-        .from("group_members")
-        .insert({ group_id: newGroup.id, user_id: userId });
+    const data = await res.json().catch(() => ({}));
 
-      if (insertMemberError) {
-        console.error("group_members insert error:", insertMemberError);
-        return NextResponse.json(
-          { error: "Internal Server Error", message: "メンバー登録に失敗しました" },
-          { status: 500 }
-        );
-      }
-
-      return NextResponse.json({
-        ok: true,
-        group_id: newGroup.id,
-        name: newGroup.name,
-        invite_code: newGroup.invite_code,
-      });
+    if (!res.ok) {
+      const message =
+        typeof data?.message === "string"
+          ? data.message
+          : "グループの作成に失敗しました";
+      return NextResponse.json(
+        { error: data?.error ?? "Internal Server Error", message },
+        { status: res.status }
+      );
     }
 
-    if (insertGroupError.code === "23505") {
-      lastError = insertGroupError;
-      continue;
-    }
-    console.error("groups insert error:", insertGroupError);
+    return NextResponse.json(data);
+  } catch (e) {
+    console.error("POST /api/groups: BFF request failed:", e);
     return NextResponse.json(
       { error: "Internal Server Error", message: "グループの作成に失敗しました" },
       { status: 500 }
     );
   }
-
-  console.error("groups insert conflict after retries:", lastError);
-  return NextResponse.json(
-    { error: "Conflict", message: "招待コードの生成に失敗しました。しばらくしてから再試行してください。" },
-    { status: 409 }
-  );
 }

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -92,8 +92,26 @@ make db-push
 | `20260228000000_initial_schema.sql`                     | 初期スキーマ（users, groups, group_members, tiles 等）       |
 | `20260228100000_tiles_score_and_users_token.sql`        | tiles の score / last_updated_at、users の Strava トークン列 |
 | `20260301000000_ensure_tiles_score_and_users_token.sql` | 上記カラムの冪等な追加（履歴未適用・手動のみ環境の救済用）   |
+| `20250303120000_enforce_rls.sql`                        | RLS 一括有効化とポリシー定義（users / tiles / group_members 等） |
 
 3 本目は `ADD COLUMN IF NOT EXISTS` のため、既にカラムがある DB では何も変わらない。**「column tiles.score does not exist」が出た場合も、`make db-push` で未適用の 3 本目が走れば解消する。**
+
+## セキュリティ・RLSポリシー
+
+Anon Key 経由の不正な読み書きを防ぐため、対象テーブルで Row Level Security（RLS）を有効化している。**Service Role Key は RLS をバイパスする**ため、バックエンドのみが書き込みを行う想定。
+
+適用内容はマイグレーション `20250303120000_enforce_rls.sql` で定義されている。
+
+| テーブル | RLS | クライアント（Anon/Authenticated）で可能な操作 | 条件・備考 |
+| -------- | --- | ---------------------------------------------- | ---------- |
+| **users** | 有効 | SELECT, UPDATE | 自分の行のみ。条件: `auth.uid() = id`。INSERT/DELETE はポリシーなし（バックエンドのみ）。 |
+| **tiles** | 有効 | SELECT のみ | 全行読み取り可（`USING (true)`）。INSERT/UPDATE/DELETE はポリシーなしで、Service Role を持つバックエンドのみ書き込み可能。 |
+| **group_members** | 有効 | SELECT のみ | 自分が所属しているレコードのみ。条件: `auth.uid() = user_id`。書き込みはバックエンドのみ。 |
+| **groups** | 有効 | なし | ポリシーを付与していないため、Anon/Authenticated では行の参照・更新不可。必要ならバックエンド経由または別マイグレーションでポリシーを追加する。 |
+| **activity_logs** | 有効 | なし | 上記と同様。クライアントからの直接アクセスは不可。 |
+
+- 認証は Supabase Auth の `auth.uid()` を前提とする。
+- クライアントからは Anon Key または Authenticated セッションで接続し、上記ポリシーの範囲内でのみアクセスできる。
 
 ## トラブルシューティング
 

--- a/supabase/migrations/20250303120000_enforce_rls.sql
+++ b/supabase/migrations/20250303120000_enforce_rls.sql
@@ -1,0 +1,49 @@
+-- Enforce RLS on all target tables to prevent unauthorized read/write via Anon Key.
+-- Service Role Key (backend) bypasses RLS; only intended client access is allowed.
+
+-- =============================================================
+-- 1. Enable ROW LEVEL SECURITY
+-- =============================================================
+
+ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE groups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE group_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE activity_logs ENABLE ROW LEVEL SECURITY;
+
+-- =============================================================
+-- 2. users: 自分のデータのみ SELECT / UPDATE 可能
+-- =============================================================
+
+DROP POLICY IF EXISTS "users_select_own" ON users;
+CREATE POLICY "users_select_own" ON users
+  FOR SELECT USING (auth.uid() = id);
+
+DROP POLICY IF EXISTS "users_update_own" ON users;
+CREATE POLICY "users_update_own" ON users
+  FOR UPDATE USING (auth.uid() = id);
+
+-- =============================================================
+-- 3. tiles: 誰でも SELECT 可能。INSERT/UPDATE/DELETE はポリシーなし
+-- （Service Role を持つバックエンドのみ書き込み可能）
+-- =============================================================
+
+DROP POLICY IF EXISTS "tiles_select_same_group" ON tiles;
+DROP POLICY IF EXISTS "tiles_select_all" ON tiles;
+CREATE POLICY "tiles_select_all" ON tiles
+  FOR SELECT USING (true);
+
+-- =============================================================
+-- 4. group_members: 自分が所属しているレコードのみ SELECT 可能
+-- =============================================================
+
+DROP POLICY IF EXISTS "group_members_select_same_group" ON group_members;
+DROP POLICY IF EXISTS "group_members_select_own" ON group_members;
+CREATE POLICY "group_members_select_own" ON group_members
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- =============================================================
+-- 5. groups / activity_logs: RLS のみ有効化
+-- ポリシーは付与しないため、Anon/Authenticated ではアクセス不可。
+-- 必要に応じてバックエンド（Service Role）または別マイグレーションでポリシーを追加すること。
+-- =============================================================


### PR DESCRIPTION
### Motivation

- Centralize writes and sensitive operations behind a backend-for-frontend (BFF) so the client no longer writes to the DB directly and so Strava tokens are not stored in plaintext. 
- Provide API endpoints for user sync (`/users/sync`) and group management (`/groups`, `/groups/join`) to simplify client logic and enforce server-side validation and retries. 
- Add symmetric token encryption support to store Strava tokens securely and enable backend-side encryption/decryption. 
- Enforce Row Level Security (RLS) in the database so only the backend (Service Role Key) can perform write operations.

### Description

- Added BFF logic: `backend-api/src/bff/users-sync.ts` and `backend-api/src/bff/groups.ts` to handle `users` upsert with token encryption and `groups` create/join with invite-code generation/retry and membership insert. 
- Added unit tests: `backend-api/src/bff/users-sync.test.ts` and `backend-api/src/bff/groups.test.ts` covering validation, success, and error paths. 
- Extended token utilities in `backend-api/src/utils/token-crypto.ts` with `encryptStravaToken` and kept `decryptStravaToken` to support AES-256-GCM encryption/decryption driven by `STRAVA_TOKEN_ENCRYPTION_KEY`. 
- Extended webhook server `backend-api/src/webhook-server.ts` to load env from the repo root, expose new endpoints (`/users/sync`, `/groups`, `/groups/join`) and route requests to the new BFF handlers, and to use encryption when syncing users. 
- Updated client flows to delegate to the BFF: the Strava OAuth callback now POSTs to the BFF `POST /users/sync` instead of writing tokens directly, and client APIs for creating/joining groups (`client/app/api/groups/route.ts`, `client/app/api/groups/join/route.ts`) call the BFF endpoints. 
- Documentation updates in `backend-api/README.md` and `supabase/README.md` describing the new BFF endpoints and RLS rationale. 
- Add migration `supabase/migrations/20250303120000_enforce_rls.sql` to enable RLS and create selection/update policies for relevant tables.

### Testing

- Ran unit tests with Vitest using `npm run test` for the backend module, and the new tests `backend-api/src/bff/users-sync.test.ts` and `backend-api/src/bff/groups.test.ts` passed. 
- No automated integration tests were added for the HTTP endpoints in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d363ff94d0832e8282848261be7728)