### PR TITLE
Add OpenAPI spec, lint script, and CI workflow

### DIFF
--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -1,0 +1,40 @@
+name: OpenAPI Lint
+
+on:
+  pull_request:
+    paths:
+      - "backend-api/openapi.yaml"
+      - "backend-api/package.json"
+      - "backend-api/package-lock.json"
+      - ".github/workflows/openapi-lint.yml"
+  push:
+    branches:
+      - develop
+    paths:
+      - "backend-api/openapi.yaml"
+      - "backend-api/package.json"
+      - "backend-api/package-lock.json"
+      - ".github/workflows/openapi-lint.yml"
+
+jobs:
+  openapi-lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend-api
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: backend-api/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint OpenAPI spec
+        run: npm run openapi:lint

--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -25,6 +25,21 @@ npm install
 - デフォルトで `http://localhost:3001/webhook/activity` で待ち受け（`PORT` 環境変数で変更可）。
 - **環境変数:** 起動時に **backend-api 直下の `.env.local` または `.env`** を自動読み込みする。`SUPABASE_URL`（または `NEXT_PUBLIC_SUPABASE_URL`）と `SUPABASE_SERVICE_ROLE_KEY` が必須。client で Strava トークンを暗号化して保存している場合は、復号用に **`STRAVA_TOKEN_ENCRYPTION_KEY`** を client と同一の値で設定する（未設定なら DB の平文トークンをそのまま使用）。`backend-api/.env.example` をコピーして `backend-api/.env.local` を作成し、値を設定する。
 
+## OpenAPI 仕様
+
+BFF/Webhook エンドポイントの仕様は `backend-api/openapi.yaml` で管理する。
+
+### ローカルでの検証
+
+```bash
+cd backend-api
+npm install
+npm run openapi:lint
+```
+
+- 構文エラー・参照不整合がある場合は `openapi:lint` が失敗する。
+- CI でも同じコマンドを実行し、仕様ファイルの破損を防ぐ。
+
 ## BFF エンドポイント（Backend For Frontend）
 
 フロントエンドからの直接 DB 操作を廃止し、バックエンド経由で行うための API。いずれも `POST`、Content-Type: `application/json`。同一の Webhook サーバー（`npm run webhook-server`）で待ち受ける。

--- a/backend-api/openapi.yaml
+++ b/backend-api/openapi.yaml
@@ -1,0 +1,287 @@
+openapi: 3.1.0
+info:
+  title: Strava Hex Turf Backend API
+  version: 1.0.0
+  license:
+    name: UNLICENSED
+  description: |
+    `backend-api/src/webhook-server.ts` で提供する HTTP API の仕様。
+servers:
+  - url: http://localhost:3001
+    description: Local webhook server
+paths:
+  /webhook/activity:
+    post:
+      summary: Process Strava activity webhook event
+      description: |
+        Strava から受け取ったアクティビティイベントを処理する。
+        `action=delete` の場合は削除処理、それ以外は作成/更新処理を実行する。
+      operationId: postWebhookActivity
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookActivityRequest'
+      responses:
+        '200':
+          description: Processed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkResponse'
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /users/sync:
+    post:
+      summary: Upsert user profile and Strava tokens
+      operationId: postUsersSync
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UsersSyncRequest'
+      responses:
+        '200':
+          description: Upsert succeeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsersSyncSuccessResponse'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /groups:
+    post:
+      summary: Create group and add owner as member
+      operationId: postGroups
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupsCreateRequest'
+      responses:
+        '200':
+          description: Group created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupsCreateSuccessResponse'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Invite code generation conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /groups/join:
+    post:
+      summary: Join group by invite code
+      operationId: postGroupsJoin
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupsJoinRequest'
+      responses:
+        '200':
+          description: Joined successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupsJoinSuccessResponse'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Group not found by invite code
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Already joined
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  schemas:
+    WebhookActivityRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - object_id
+        - owner_id
+      properties:
+        object_id:
+          type: integer
+          description: Strava activity id
+        owner_id:
+          type: integer
+          description: Strava athlete id
+        action:
+          type: string
+          description: delete の場合は削除イベントとして扱う
+          enum: [create, update, delete]
+
+    UsersSyncRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - strava_id
+        - access_token
+        - refresh_token
+      properties:
+        strava_id:
+          type: integer
+        access_token:
+          type: string
+        refresh_token:
+          type: string
+        display_name:
+          type: [string, "null"]
+        profile_image_url:
+          type: [string, "null"]
+        icon_url:
+          type: [string, "null"]
+        strava_token_expires_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: "null"
+
+    GroupsCreateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - user_id
+      properties:
+        name:
+          type: string
+        user_id:
+          type: string
+          format: uuid
+
+    GroupsJoinRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - invite_code
+        - user_id
+      properties:
+        invite_code:
+          type: string
+          pattern: '^[A-Fa-f0-9]{8}$'
+        user_id:
+          type: string
+          format: uuid
+
+    OkResponse:
+      type: object
+      additionalProperties: false
+      required: [ok]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+
+    UsersSyncSuccessResponse:
+      type: object
+      additionalProperties: false
+      required: [ok, id]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        id:
+          type: string
+          format: uuid
+
+    GroupsCreateSuccessResponse:
+      type: object
+      additionalProperties: false
+      required: [ok, group_id, name, invite_code]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        group_id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        invite_code:
+          type: string
+          pattern: '^[A-Fa-f0-9]{8}$'
+
+    GroupsJoinSuccessResponse:
+      type: object
+      additionalProperties: false
+      required: [ok, group_id]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        group_id:
+          type: string
+          format: uuid
+
+    ErrorResponse:
+      type: object
+      additionalProperties: true
+      required: [error]
+      properties:
+        error:
+          type: string

--- a/backend-api/package.json
+++ b/backend-api/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
-    "webhook-server": "node dist/webhook-server.js"
+    "webhook-server": "node dist/webhook-server.js",
+    "openapi:lint": "npx --yes @redocly/cli@1.27.1 lint openapi.yaml"
   },
   "dependencies": {
     "@mapbox/polyline": "^1.2.1",


### PR DESCRIPTION
### Motivation

- Provide a maintained OpenAPI specification for the backend API to make the API contract explicit and machine-readable.
- Prevent accidental syntax or reference regressions by validating the OpenAPI file in CI and locally.

### Description

- Add `backend-api/openapi.yaml` containing the API paths, request/response schemas, and components for webhook, users, and groups endpoints.
- Add an `openapi:lint` npm script to `backend-api/package.json` that runs `npx --yes @redocly/cli@1.27.1 lint openapi.yaml`.
- Add a GitHub Actions workflow `.github/workflows/openapi-lint.yml` that checks out the repo, installs Node.js, runs `npm ci`, and executes `npm run openapi:lint` on PRs touching the spec and on pushes to `develop`.
- Update `backend-api/README.md` with an "OpenAPI 仕様" section and local validation instructions showing how to run the linter locally.

### Testing

- No automated tests were executed as part of this change during the rollout.
- The added CI job `OpenAPI Lint` will run `npm run openapi:lint` on pull requests and pushes to `develop` to validate the OpenAPI file going forward.
- Existing test commands (`npm run test`) were not modified by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d36f0ab7e4832e9a589ed017c2dcdf)