### PR TITLE
fix: extend stats chart range through today (#40)

### DIFF
--- a/client/components/organisms/UserStatsView.tsx
+++ b/client/components/organisms/UserStatsView.tsx
@@ -32,8 +32,26 @@ const RANGE_DAYS: Record<RangeKey, number> = {
 };
 
 function formatDateLabel(dateStr: string): string {
-  const d = new Date(dateStr);
+  const d = parseDateOnly(dateStr);
   return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+function parseDateOnly(dateStr: string): Date {
+  const [y, m, d] = dateStr.split("-").map((v) => Number(v));
+  return new Date(y, (m || 1) - 1, d || 1);
+}
+
+function toDateOnlyString(date: Date): string {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
 }
 
 export function UserStatsView({ groupId, userId, displayName, iconUrl, groupName }: UserStatsViewProps) {
@@ -73,12 +91,33 @@ export function UserStatsView({ groupId, userId, displayName, iconUrl, groupName
   }, [fetchStats]);
 
   const days = RANGE_DAYS[range];
-  const chartData = stats
-    .slice(-days)
-    .map((d) => ({
-      ...d,
-      dateLabel: formatDateLabel(d.record_date),
-    }));
+  const today = new Date();
+  const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const startDate = addDays(endDate, -(days - 1));
+
+  const statByDate = new Map(stats.map((d) => [d.record_date, d]));
+  const sortedStats = [...stats].sort((a, b) => a.record_date.localeCompare(b.record_date));
+  let cursor = 0;
+  let lastKnown: UserGroupDailyStat | null = null;
+
+  const chartData: Array<UserGroupDailyStat & { dateLabel: string }> = [];
+  for (let d = startDate; d <= endDate; d = addDays(d, 1)) {
+    const key = toDateOnlyString(d);
+    const exact = statByDate.get(key);
+
+    while (cursor < sortedStats.length && sortedStats[cursor].record_date <= key) {
+      lastKnown = sortedStats[cursor];
+      cursor += 1;
+    }
+
+    const source = exact ?? lastKnown;
+    chartData.push({
+      record_date: key,
+      tile_count: source?.tile_count ?? 0,
+      total_score: source?.total_score ?? 0,
+      dateLabel: formatDateLabel(key),
+    });
+  }
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
### Motivation
- The stats-over-time chart stopped at the last persisted snapshot date instead of extending to the current date, causing the X axis to remain stale.  
- The UI should display a continuous daily series up to today for the selected range (1W/1M/1Y) and avoid timezone-driven label drift.  

### Description
- Updated `UserStatsView` to generate chart points for every day in the selected range with the end date set to today instead of slicing the last N rows.  
- Added date utilities `parseDateOnly`, `toDateOnlyString`, and `addDays` and switched `formatDateLabel` to use `parseDateOnly` to avoid timezone-related issues when parsing `YYYY-MM-DD`.  
- Implemented filling of missing days by carrying forward the most recent known `UserGroupDailyStat` (or `0` if none) and building `chartData` from `startDate`..`endDate`.  
- No API or DB schema changes were made; this is a frontend-only behavior fix in `client/components/organisms/UserStatsView.tsx` (46 insertions, 7 deletions).  

### Testing
- Ran backend unit tests with `cd backend-api && npm test`, and all tests passed (`Test Files 4 passed`, `Tests 36 passed`).  
- Attempted client lint with `cd client && npm run lint`, but the process triggered Next.js ESLint interactive setup which cannot complete in this environment, so linting was not completed.  
- Verified the change compiles in the repository and committed as `fix: extend stats chart range through today (#40)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d37308a1f4832e9967e2f8ff101bb4)