### PR TITLE
Add one-time initial backfill flow for newly-synced users

### DIFF
--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -62,13 +62,27 @@ npm run openapi:lint
 ### POST /users/initial-backfill
 
 初回連携時のみ、対象ユーザーの過去7日分の Strava アクティビティを取り込み、タイル反映を実行する。
+このエンドポイントは内部実行専用で、`x-internal-backfill-key` ヘッダーが `INTERNAL_BACKFILL_API_KEY` と一致しない場合は `403` を返す。
 
 - **リクエストボディ（JSON）**
   - `strava_id` (number, 必須): Strava の Athlete ID
+  - `base_time` (string, 任意): 取り込み基点時刻（ISO 8601）。未指定時はサーバー現在時刻。
 - **レスポンス**
-  - 成功（初回取り込み実行）: `200` + `{ "ok": true, "processed_activity_count": number }`
+  - 成功（初回取り込み実行）: `200` + `{ "ok": true, "processed_activity_count": number, "base_time": "..." }`
   - 成功（既に実行済み）: `200` + `{ "ok": true, "skipped": true }`
-  - 失敗: `400`（必須項目不足・不正）/ `404`（ユーザー未登録）/ `500` + `{ "error": "メッセージ" }`
+  - 失敗: `400`（必須項目不足・不正）/ `403`（内部キー不一致）/ `404`（ユーザー未登録）/ `500` + `{ "error": "メッセージ" }`
+
+#### 動作確認用スクリプト（内部向け）
+
+リポジトリ直下の `scripts/run-initial-backfill.sh` で、基点時刻を指定してバックフィルを実行できる。
+
+```bash
+INTERNAL_BACKFILL_API_KEY=xxxxx BACKEND_API_URL=http://localhost:3001 \
+  ./scripts/run-initial-backfill.sh 123456 2026-04-06T00:00:00Z
+```
+
+- 第2引数（基点時刻）省略時は現在時刻（UTC）を使用。
+- 実行は内部キーが必要なため、一般ユーザーからは直接実行できない。
 
 ### POST /groups
 

--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -56,8 +56,19 @@ npm run openapi:lint
   - `profile_image_url` / `icon_url` (string | null, 任意): アイコン URL
   - `strava_token_expires_at` (string | null, 任意): トークン有効期限（ISO 8601）
 - **レスポンス**
-  - 成功: `200` + `{ "ok": true }`
+  - 成功: `200` + `{ "ok": true, "id": "uuid", "should_run_initial_backfill": true|false }`
   - 失敗: `400`（必須項目不足・不正）/ `500`（暗号化失敗・DB エラー） + `{ "error": "メッセージ" }`
+
+### POST /users/initial-backfill
+
+初回連携時のみ、対象ユーザーの過去7日分の Strava アクティビティを取り込み、タイル反映を実行する。
+
+- **リクエストボディ（JSON）**
+  - `strava_id` (number, 必須): Strava の Athlete ID
+- **レスポンス**
+  - 成功（初回取り込み実行）: `200` + `{ "ok": true, "processed_activity_count": number }`
+  - 成功（既に実行済み）: `200` + `{ "ok": true, "skipped": true }`
+  - 失敗: `400`（必須項目不足・不正）/ `404`（ユーザー未登録）/ `500` + `{ "error": "メッセージ" }`
 
 ### POST /groups
 

--- a/backend-api/openapi.yaml
+++ b/backend-api/openapi.yaml
@@ -75,6 +75,43 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /users/initial-backfill:
+    post:
+      summary: Backfill user's activities for past 7 days only once
+      operationId: postUsersInitialBackfill
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UsersInitialBackfillRequest'
+      responses:
+        '200':
+          description: Backfill processed (or skipped if already done)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsersInitialBackfillSuccessResponse'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /groups:
     post:
       summary: Create group and add owner as member
@@ -201,6 +238,15 @@ components:
               format: date-time
             - type: "null"
 
+    UsersInitialBackfillRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - strava_id
+      properties:
+        strava_id:
+          type: integer
+
     GroupsCreateRequest:
       type: object
       additionalProperties: false
@@ -240,7 +286,7 @@ components:
     UsersSyncSuccessResponse:
       type: object
       additionalProperties: false
-      required: [ok, id]
+      required: [ok, id, should_run_initial_backfill]
       properties:
         ok:
           type: boolean
@@ -248,6 +294,21 @@ components:
         id:
           type: string
           format: uuid
+        should_run_initial_backfill:
+          type: boolean
+
+    UsersInitialBackfillSuccessResponse:
+      type: object
+      additionalProperties: true
+      required: [ok]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        skipped:
+          type: boolean
+        processed_activity_count:
+          type: integer
 
     GroupsCreateSuccessResponse:
       type: object

--- a/backend-api/openapi.yaml
+++ b/backend-api/openapi.yaml
@@ -80,6 +80,13 @@ paths:
       summary: Backfill user's activities for past 7 days only once
       operationId: postUsersInitialBackfill
       security: []
+      parameters:
+        - in: header
+          name: x-internal-backfill-key
+          required: true
+          schema:
+            type: string
+          description: INTERNAL_BACKFILL_API_KEY と一致する内部キー
       requestBody:
         required: true
         content:
@@ -101,6 +108,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden
           content:
             application/json:
               schema:
@@ -246,6 +259,12 @@ components:
       properties:
         strava_id:
           type: integer
+        base_time:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: "null"
+          description: 取り込み基点時刻（未指定時はサーバ現在時刻）
 
     GroupsCreateRequest:
       type: object
@@ -309,6 +328,9 @@ components:
           type: boolean
         processed_activity_count:
           type: integer
+        base_time:
+          type: string
+          format: date-time
 
     GroupsCreateSuccessResponse:
       type: object

--- a/backend-api/src/bff/users-sync.test.ts
+++ b/backend-api/src/bff/users-sync.test.ts
@@ -10,14 +10,47 @@ const validBody: UsersSyncBody = {
   strava_token_expires_at: "2025-12-31T00:00:00Z",
 };
 
+function createSupabaseMock(options?: {
+  existingUser?: { id: string; initial_backfill_done_at: string | null } | null;
+  existingUserError?: string | null;
+  upsertData?: { id?: string } | null;
+  upsertError?: string | null;
+}) {
+  const existingUser = options?.existingUser ?? null;
+  const existingUserError = options?.existingUserError ?? null;
+  const upsertData = options?.upsertData ?? { id: "user-1" };
+  const upsertError = options?.upsertError ?? null;
+
+  const mockExistingMaybeSingle = vi
+    .fn()
+    .mockResolvedValue({ data: existingUser, error: existingUserError ? { message: existingUserError } : null });
+  const mockExistingEq = vi.fn(() => ({ maybeSingle: mockExistingMaybeSingle }));
+  const mockExistingSelect = vi.fn(() => ({ eq: mockExistingEq }));
+
+  const mockUpsertSingle = vi
+    .fn()
+    .mockResolvedValue({ data: upsertData, error: upsertError ? { message: upsertError } : null });
+  const mockUpsertSelect = vi.fn(() => ({ single: mockUpsertSingle }));
+  const mockUpsert = vi.fn(() => ({ select: mockUpsertSelect }));
+
+  const mockFrom = vi.fn((_table: string) => ({
+    select: mockExistingSelect,
+    upsert: mockUpsert,
+  }));
+
+  return {
+    supabase: { from: mockFrom },
+    mocks: {
+      mockFrom,
+      mockUpsert,
+    },
+  };
+}
+
 describe("runUsersSync", () => {
   it("必須項目が欠けている場合は 400", async () => {
     const encrypt = vi.fn((s: string) => `enc:${s}`);
-    const mockSingle = vi.fn().mockResolvedValue({ data: { id: "user-1" }, error: null });
-    const mockSelect = vi.fn(() => ({ single: mockSingle }));
-    const mockUpsert = vi.fn(() => ({ select: mockSelect }));
-    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
-    const supabase = { from: mockFrom };
+    const { supabase } = createSupabaseMock();
 
     const missingStravaId = { ...validBody, strava_id: undefined } as unknown as UsersSyncBody;
     expect(await runUsersSync(supabase as never, missingStravaId, encrypt)).toEqual({
@@ -36,11 +69,7 @@ describe("runUsersSync", () => {
 
   it("暗号化が null を返す場合は 500", async () => {
     const encrypt = vi.fn(() => null);
-    const mockSingle = vi.fn().mockResolvedValue({ data: { id: "user-1" }, error: null });
-    const mockSelect = vi.fn(() => ({ single: mockSingle }));
-    const mockUpsert = vi.fn(() => ({ select: mockSelect }));
-    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
-    const supabase = { from: mockFrom };
+    const { supabase } = createSupabaseMock();
 
     const result = await runUsersSync(supabase as never, validBody, encrypt);
     expect(result).toEqual({ ok: false, statusCode: 500, error: "Token encryption failed" });
@@ -48,15 +77,11 @@ describe("runUsersSync", () => {
 
   it("upsert 成功時は ok: true と id を返す", async () => {
     const encrypt = vi.fn((s: string) => `enc:${s}`);
-    const mockSingle = vi.fn().mockResolvedValue({ data: { id: "user-1" }, error: null });
-    const mockSelect = vi.fn(() => ({ single: mockSingle }));
-    const mockUpsert = vi.fn(() => ({ select: mockSelect }));
-    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
-    const supabase = { from: mockFrom };
+    const { supabase, mocks } = createSupabaseMock();
 
     const result = await runUsersSync(supabase as never, validBody, encrypt);
-    expect(result).toEqual({ ok: true, id: "user-1" });
-    expect(mockUpsert).toHaveBeenCalledWith(
+    expect(result).toEqual({ ok: true, id: "user-1", should_run_initial_backfill: true });
+    expect(mocks.mockUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         strava_id: 12345,
         display_name: "Test User",
@@ -71,15 +96,11 @@ describe("runUsersSync", () => {
 
   it("display_name が空の場合は User {strava_id} になる", async () => {
     const encrypt = vi.fn((s: string) => `enc:${s}`);
-    const mockSingle = vi.fn().mockResolvedValue({ data: { id: "user-1" }, error: null });
-    const mockSelect = vi.fn(() => ({ single: mockSingle }));
-    const mockUpsert = vi.fn(() => ({ select: mockSelect }));
-    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
-    const supabase = { from: mockFrom };
+    const { supabase, mocks } = createSupabaseMock();
     const body = { ...validBody, display_name: "", profile_image_url: null };
 
     await runUsersSync(supabase as never, body, encrypt);
-    expect(mockUpsert).toHaveBeenCalledWith(
+    expect(mocks.mockUpsert).toHaveBeenCalledWith(
       expect.objectContaining({ display_name: "User 12345" }),
       expect.any(Object)
     );
@@ -87,11 +108,7 @@ describe("runUsersSync", () => {
 
   it("Supabase upsert がエラーの場合は 500", async () => {
     const encrypt = vi.fn((s: string) => `enc:${s}`);
-    const mockSingle = vi.fn().mockResolvedValue({ data: null, error: { message: "DB error" } });
-    const mockSelect = vi.fn(() => ({ single: mockSingle }));
-    const mockUpsert = vi.fn(() => ({ select: mockSelect }));
-    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
-    const supabase = { from: mockFrom };
+    const { supabase } = createSupabaseMock({ upsertData: null, upsertError: "DB error" });
 
     const result = await runUsersSync(supabase as never, validBody, encrypt);
     expect(result).toEqual({ ok: false, statusCode: 500, error: "DB error" });
@@ -99,11 +116,7 @@ describe("runUsersSync", () => {
 
   it("upsert は成功したが id が無い場合は 500", async () => {
     const encrypt = vi.fn((s: string) => `enc:${s}`);
-    const mockSingle = vi.fn().mockResolvedValue({ data: {}, error: null });
-    const mockSelect = vi.fn(() => ({ single: mockSingle }));
-    const mockUpsert = vi.fn(() => ({ select: mockSelect }));
-    const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
-    const supabase = { from: mockFrom };
+    const { supabase } = createSupabaseMock({ upsertData: {}, upsertError: null });
 
     const result = await runUsersSync(supabase as never, validBody, encrypt);
     expect(result).toEqual({
@@ -111,5 +124,15 @@ describe("runUsersSync", () => {
       statusCode: 500,
       error: "users upsert succeeded but id was missing",
     });
+  });
+
+  it("既存ユーザーで initial_backfill_done_at がある場合 should_run_initial_backfill は false", async () => {
+    const encrypt = vi.fn((s: string) => `enc:${s}`);
+    const { supabase } = createSupabaseMock({
+      existingUser: { id: "user-1", initial_backfill_done_at: "2026-01-01T00:00:00Z" },
+    });
+
+    const result = await runUsersSync(supabase as never, validBody, encrypt);
+    expect(result).toEqual({ ok: true, id: "user-1", should_run_initial_backfill: false });
   });
 });

--- a/backend-api/src/bff/users-sync.ts
+++ b/backend-api/src/bff/users-sync.ts
@@ -14,7 +14,7 @@ export interface UsersSyncBody {
 }
 
 export type UsersSyncResult =
-  | { ok: true; id: string }
+  | { ok: true; id: string; should_run_initial_backfill: boolean }
   | { ok: false; statusCode: number; error: string };
 
 export type EncryptFn = (plaintext: string) => string | null;
@@ -63,6 +63,24 @@ export async function runUsersSync(
     updated_at: new Date().toISOString(),
   };
 
+  const { data: existingUser, error: existingUserError } = await supabase
+    .from("users")
+    .select("id, initial_backfill_done_at")
+    .eq("strava_id", body.strava_id)
+    .maybeSingle();
+
+  if (existingUserError) {
+    return { ok: false, statusCode: 500, error: existingUserError.message };
+  }
+  const shouldRunInitialBackfill =
+    !existingUser ||
+    !(
+      typeof (existingUser as { initial_backfill_done_at?: string | null })
+        .initial_backfill_done_at === "string" &&
+      (existingUser as { initial_backfill_done_at?: string | null })
+        .initial_backfill_done_at
+    );
+
   const { data, error } = await supabase
     .from("users")
     .upsert(row, { onConflict: "strava_id" })
@@ -75,5 +93,5 @@ export async function runUsersSync(
   if (!data?.id || typeof data.id !== "string") {
     return { ok: false, statusCode: 500, error: "users upsert succeeded but id was missing" };
   }
-  return { ok: true, id: data.id };
+  return { ok: true, id: data.id, should_run_initial_backfill: shouldRunInitialBackfill };
 }

--- a/backend-api/src/webhook-server.ts
+++ b/backend-api/src/webhook-server.ts
@@ -42,6 +42,7 @@ loadEnvFromCwd();
 const PORT = Number(process.env.PORT) || 3001;
 const PATH_WEBHOOK = "/webhook/activity";
 const PATH_USERS_SYNC = "/users/sync";
+const PATH_USERS_INITIAL_BACKFILL = "/users/initial-backfill";
 const PATH_GROUPS = "/groups";
 const PATH_GROUPS_JOIN = "/groups/join";
 
@@ -96,7 +97,13 @@ async function handleUsersSync(req: IncomingMessage, res: ServerResponse): Promi
     const result = await runUsersSync(getSupabase(), body, encryptStravaToken);
     if (result.ok) {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: true, id: result.id }));
+      res.end(
+        JSON.stringify({
+          ok: true,
+          id: result.id,
+          should_run_initial_backfill: result.should_run_initial_backfill,
+        })
+      );
       return;
     }
     res.writeHead(result.statusCode, { "Content-Type": "application/json" });
@@ -104,6 +111,112 @@ async function handleUsersSync(req: IncomingMessage, res: ServerResponse): Promi
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error("[webhook-server] users/sync error:", err);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: msg }));
+  }
+}
+
+async function fetchRecentActivityIds(accessToken: string, days: number): Promise<number[]> {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const afterSec = nowSec - days * 24 * 60 * 60;
+  const perPage = 200;
+  let page = 1;
+  const ids: number[] = [];
+
+  while (true) {
+    const params = new URLSearchParams({
+      after: String(afterSec),
+      per_page: String(perPage),
+      page: String(page),
+    });
+    const res = await fetch(`https://www.strava.com/api/v3/athlete/activities?${params.toString()}`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Strava athlete activities API ${res.status}: ${text}`);
+    }
+    const rows = (await res.json()) as Array<{ id?: number }>;
+    const pageIds = rows
+      .map((row) => row.id)
+      .filter((id): id is number => typeof id === "number");
+    ids.push(...pageIds);
+    if (rows.length < perPage) break;
+    page += 1;
+  }
+
+  return ids;
+}
+
+async function handleUsersInitialBackfill(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await parseJsonBody<{ strava_id?: number }>(req);
+  if (!body || typeof body.strava_id !== "number") {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Missing or invalid strava_id" }));
+    return;
+  }
+
+  const supabase = getSupabase();
+  const { data: user, error: userError } = await supabase
+    .from("users")
+    .select("id, strava_access_token, initial_backfill_done_at")
+    .eq("strava_id", body.strava_id)
+    .maybeSingle();
+
+  if (userError) {
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: userError.message }));
+    return;
+  }
+  if (!user) {
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "user not found" }));
+    return;
+  }
+
+  const userRow = user as {
+    id: string;
+    strava_access_token: string | null;
+    initial_backfill_done_at: string | null;
+  };
+  if (userRow.initial_backfill_done_at) {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true, skipped: true }));
+    return;
+  }
+  if (!userRow.strava_access_token) {
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "user has no strava_access_token" }));
+    return;
+  }
+
+  const token = decryptStravaToken(userRow.strava_access_token);
+  if (!token) {
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "strava_access_token decryption failed" }));
+    return;
+  }
+
+  try {
+    const activityIds = await fetchRecentActivityIds(token, 7);
+    const deps = createDefaultDeps(supabase, decryptStravaToken);
+    for (const activityId of activityIds) {
+      const result = await processActivityEvent(activityId, body.strava_id, deps);
+      if (result.ok || result.reason === "activity has no map.summary_polyline") continue;
+      throw new Error(result.reason);
+    }
+
+    const { error: updateError } = await supabase
+      .from("users")
+      .update({ initial_backfill_done_at: new Date().toISOString() })
+      .eq("id", userRow.id);
+    if (updateError) throw new Error(updateError.message);
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true, processed_activity_count: activityIds.length }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[webhook-server] users/initial-backfill error:", err);
     res.writeHead(500, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: msg }));
   }
@@ -265,6 +378,8 @@ const server = createServer(async (req, res) => {
     await handlePost(req, res);
   } else if (req.method === "POST" && path === PATH_USERS_SYNC) {
     await handleUsersSync(req, res);
+  } else if (req.method === "POST" && path === PATH_USERS_INITIAL_BACKFILL) {
+    await handleUsersInitialBackfill(req, res);
   } else if (req.method === "POST" && path === PATH_GROUPS) {
     await handleGroupsCreate(req, res);
   } else if (req.method === "POST" && path === PATH_GROUPS_JOIN) {
@@ -277,5 +392,6 @@ const server = createServer(async (req, res) => {
 server.listen(PORT, () => {
   console.log(`Webhook server listening on http://localhost:${PORT}${PATH_WEBHOOK}`);
   console.log(`Users sync: http://localhost:${PORT}${PATH_USERS_SYNC}`);
+  console.log(`Users initial backfill: http://localhost:${PORT}${PATH_USERS_INITIAL_BACKFILL}`);
   console.log(`Groups: http://localhost:${PORT}${PATH_GROUPS}, http://localhost:${PORT}${PATH_GROUPS_JOIN}`);
 });

--- a/backend-api/src/webhook-server.ts
+++ b/backend-api/src/webhook-server.ts
@@ -116,9 +116,9 @@ async function handleUsersSync(req: IncomingMessage, res: ServerResponse): Promi
   }
 }
 
-async function fetchRecentActivityIds(accessToken: string, days: number): Promise<number[]> {
-  const nowSec = Math.floor(Date.now() / 1000);
-  const afterSec = nowSec - days * 24 * 60 * 60;
+async function fetchRecentActivityIds(accessToken: string, days: number, baseTime: Date): Promise<number[]> {
+  const baseSec = Math.floor(baseTime.getTime() / 1000);
+  const afterSec = baseSec - days * 24 * 60 * 60;
   const perPage = 200;
   let page = 1;
   const ids: number[] = [];
@@ -149,10 +149,24 @@ async function fetchRecentActivityIds(accessToken: string, days: number): Promis
 }
 
 async function handleUsersInitialBackfill(req: IncomingMessage, res: ServerResponse): Promise<void> {
-  const body = await parseJsonBody<{ strava_id?: number }>(req);
+  const expectedKey = process.env.INTERNAL_BACKFILL_API_KEY ?? "";
+  const requestKey = req.headers["x-internal-backfill-key"];
+  if (!expectedKey || requestKey !== expectedKey) {
+    res.writeHead(403, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Forbidden" }));
+    return;
+  }
+
+  const body = await parseJsonBody<{ strava_id?: number; base_time?: string }>(req);
   if (!body || typeof body.strava_id !== "number") {
     res.writeHead(400, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Missing or invalid strava_id" }));
+    return;
+  }
+  const baseTime = body.base_time ? new Date(body.base_time) : new Date();
+  if (Number.isNaN(baseTime.getTime())) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Missing or invalid base_time" }));
     return;
   }
 
@@ -198,7 +212,7 @@ async function handleUsersInitialBackfill(req: IncomingMessage, res: ServerRespo
   }
 
   try {
-    const activityIds = await fetchRecentActivityIds(token, 7);
+    const activityIds = await fetchRecentActivityIds(token, 7, baseTime);
     const deps = createDefaultDeps(supabase, decryptStravaToken);
     for (const activityId of activityIds) {
       const result = await processActivityEvent(activityId, body.strava_id, deps);
@@ -213,7 +227,13 @@ async function handleUsersInitialBackfill(req: IncomingMessage, res: ServerRespo
     if (updateError) throw new Error(updateError.message);
 
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ ok: true, processed_activity_count: activityIds.length }));
+    res.end(
+      JSON.stringify({
+        ok: true,
+        processed_activity_count: activityIds.length,
+        base_time: baseTime.toISOString(),
+      })
+    );
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error("[webhook-server] users/initial-backfill error:", err);

--- a/client/app/api/auth/strava/callback/route.ts
+++ b/client/app/api/auth/strava/callback/route.ts
@@ -112,7 +112,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${baseRedirect}/login?error=upsert`);
   }
 
-  let syncData: { id?: string };
+  let syncData: { id?: string; should_run_initial_backfill?: boolean };
   try {
     syncData = (await syncRes.json()) as { id?: string };
   } catch {
@@ -123,6 +123,16 @@ export async function GET(request: NextRequest) {
   if (!syncData?.id) {
     console.error("User sync: response missing id");
     return NextResponse.redirect(`${baseRedirect}/login?error=upsert`);
+  }
+
+  if (syncData.should_run_initial_backfill === true) {
+    void fetch(`${backendUrl}/users/initial-backfill`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ strava_id: athlete.id }),
+    }).catch((e) => {
+      console.error("Initial backfill request failed:", e);
+    });
   }
 
   const token = await createSessionToken(syncData.id);

--- a/client/app/api/auth/strava/callback/route.ts
+++ b/client/app/api/auth/strava/callback/route.ts
@@ -126,13 +126,21 @@ export async function GET(request: NextRequest) {
   }
 
   if (syncData.should_run_initial_backfill === true) {
-    void fetch(`${backendUrl}/users/initial-backfill`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ strava_id: athlete.id }),
-    }).catch((e) => {
-      console.error("Initial backfill request failed:", e);
-    });
+    const internalBackfillApiKey = process.env.INTERNAL_BACKFILL_API_KEY ?? "";
+    if (!internalBackfillApiKey) {
+      console.error("Initial backfill request skipped: INTERNAL_BACKFILL_API_KEY is not configured");
+    } else {
+      void fetch(`${backendUrl}/users/initial-backfill`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-internal-backfill-key": internalBackfillApiKey,
+        },
+        body: JSON.stringify({ strava_id: athlete.id }),
+      }).catch((e) => {
+        console.error("Initial backfill request failed:", e);
+      });
+    }
   }
 
   const token = await createSessionToken(syncData.id);

--- a/scripts/run-initial-backfill.sh
+++ b/scripts/run-initial-backfill.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <strava_id> [base_time_iso8601]"
+  echo "Example: $0 123456 2026-04-06T00:00:00Z"
+  exit 1
+fi
+
+STRAVA_ID="$1"
+BASE_TIME="${2:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+BACKEND_API_URL="${BACKEND_API_URL:-http://localhost:3001}"
+INTERNAL_KEY="${INTERNAL_BACKFILL_API_KEY:-}"
+
+if [[ -z "$INTERNAL_KEY" ]]; then
+  echo "Error: INTERNAL_BACKFILL_API_KEY is required"
+  exit 1
+fi
+
+response="$(curl -sS -X POST "${BACKEND_API_URL%/}/users/initial-backfill" \
+  -H "Content-Type: application/json" \
+  -H "x-internal-backfill-key: ${INTERNAL_KEY}" \
+  -d "{\"strava_id\": ${STRAVA_ID}, \"base_time\": \"${BASE_TIME}\"}")"
+
+if command -v jq >/dev/null 2>&1; then
+  echo "$response" | jq .
+else
+  echo "$response"
+fi

--- a/supabase/migrations/20260406100000_add_users_initial_backfill_done_at.sql
+++ b/supabase/migrations/20260406100000_add_users_initial_backfill_done_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS initial_backfill_done_at TIMESTAMPTZ;


### PR DESCRIPTION
### Motivation

- Provide a way to import a user's recent Strava activities once after first sync and mark the user as backfilled to avoid duplicate work.

### Description

- Return `should_run_initial_backfill` from `runUsersSync` and include it in the `POST /users/sync` response, computing the flag by checking `initial_backfill_done_at` on the existing `users` row.
- Add a new endpoint `POST /users/initial-backfill` implemented in `handleUsersInitialBackfill` which looks up the user, decrypts the stored token, fetches recent activity IDs (`fetchRecentActivityIds`), processes each activity via `processActivityEvent`, updates `initial_backfill_done_at`, and returns `{ ok: true, processed_activity_count }` or `{ ok: true, skipped: true }` when already done.
- Wire the server routes and path constants, update the client callback to trigger the backfill request when `should_run_initial_backfill` is true, and update OpenAPI (`openapi.yaml`) and `backend-api/README.md` accordingly.
- Add a DB migration `supabase/migrations/20260406100000_add_users_initial_backfill_done_at.sql` to add the `initial_backfill_done_at` column and update `users-sync` unit tests (`users-sync.test.ts`) with a reusable supabase mock and new assertions.

### Testing

- Ran the backend unit tests (`vitest`) for `backend-api/src/bff/users-sync.test.ts` and the updated test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d37ea34448832e95f5171ea59cabe0)