### PR TITLE
Handle Strava deauthorization webhook and remove users by strava_id

### DIFF
--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -19,11 +19,27 @@ npm install
 
 ## Webhook サーバー（Strava アクティビティ処理用）
 
-クライアント（Next.js）の `/api/strava/webhook` が Strava から POST を受信した際、本サーバーの `POST /webhook/activity` を呼び出して `processActivityEvent` を実行する。
+クライアント（Next.js）の `/api/strava/webhook` が Strava から POST を受信した際、本サーバーの `POST /webhook/activity`（アクティビティ）または `POST /webhook/deauthorization`（連携解除）を呼び出す。
+
+- **Strava アプリ設定の Callback URL:** `https://<your-domain>/api/strava/webhook`（ローカル検証時は `http://localhost:3000/api/strava/webhook`）。
 
 - **起動:** `npm run build` の後に `npm run webhook-server`（`backend-api` ディレクトリで実行すること）。
 - デフォルトで `http://localhost:3001/webhook/activity` で待ち受け（`PORT` 環境変数で変更可）。
 - **環境変数:** 起動時に **backend-api 直下の `.env.local` または `.env`** を自動読み込みする。`SUPABASE_URL`（または `NEXT_PUBLIC_SUPABASE_URL`）と `SUPABASE_SERVICE_ROLE_KEY` が必須。client で Strava トークンを暗号化して保存している場合は、復号用に **`STRAVA_TOKEN_ENCRYPTION_KEY`** を client と同一の値で設定する（未設定なら DB の平文トークンをそのまま使用）。`backend-api/.env.example` をコピーして `backend-api/.env.local` を作成し、値を設定する。
+
+
+### POST /webhook/deauthorization
+
+Strava webhook の `object_type=athlete`（`aspect_type=update` / `delete`）を受け取り、`owner_id` をキーに `users.strava_id` を検索して `users` 行を削除する。
+`users` からの削除は既存 FK の `ON DELETE CASCADE` 前提で、関連行（タイル・ログ等）も同時に削除される。
+
+- **リクエストボディ（JSON）**
+  - `owner_id` (number, 必須): Strava の Athlete ID
+- **レスポンス**
+  - 成功: `200` + `{ "ok": true }`
+  - 対象なし: `200` + `{ "ok": true, "skipped": true }`
+  - 失敗: `400`（必須項目不足・不正）/ `500`（DB エラー） + `{ "error": "メッセージ" }`
+- **リトライ方針:** `500` 時は webhook 再送で再試行可能。サーバーログには `deauthorization ... (retryable)` として `owner_id` とエラー内容を出力する。
 
 ## OpenAPI 仕様
 

--- a/backend-api/openapi.yaml
+++ b/backend-api/openapi.yaml
@@ -44,6 +44,40 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /webhook/deauthorization:
+    post:
+      summary: Process Strava deauthorization webhook event
+      description: |
+        Strava webhook の deauthorization（`object_type=athlete` + `aspect_type=update/delete`）を処理する。
+        `owner_id`（Strava athlete id）に一致する `users.strava_id` の行を削除する。
+      operationId: postWebhookDeauthorization
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookDeauthorizationRequest'
+      responses:
+        '200':
+          description: Processed successfully (or skipped when user not found)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkResponse'
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Processing failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /users/sync:
     post:
       summary: Upsert user profile and Strava tokens
@@ -224,6 +258,17 @@ components:
           type: string
           description: delete の場合は削除イベントとして扱う
           enum: [create, update, delete]
+
+
+    WebhookDeauthorizationRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - owner_id
+      properties:
+        owner_id:
+          type: integer
+          description: Strava athlete id
 
     UsersSyncRequest:
       type: object

--- a/backend-api/src/webhook-server.ts
+++ b/backend-api/src/webhook-server.ts
@@ -43,6 +43,7 @@ const PORT = Number(process.env.PORT) || 3001;
 const PATH_WEBHOOK = "/webhook/activity";
 const PATH_USERS_SYNC = "/users/sync";
 const PATH_USERS_INITIAL_BACKFILL = "/users/initial-backfill";
+const PATH_WEBHOOK_DEAUTHORIZATION = "/webhook/deauthorization";
 const PATH_GROUPS = "/groups";
 const PATH_GROUPS_JOIN = "/groups/join";
 
@@ -84,6 +85,80 @@ function parseWebhookBody(req: IncomingMessage): Promise<{ object_id: number; ow
     }
     return null;
   });
+}
+
+
+function parseDeauthorizationBody(req: IncomingMessage): Promise<{ owner_id: number } | null> {
+  return parseJsonBody(req).then((body) => {
+    if (body && typeof (body as { owner_id?: number }).owner_id === "number") {
+      return { owner_id: (body as { owner_id: number }).owner_id };
+    }
+    return null;
+  });
+}
+
+async function handleWebhookDeauthorization(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await parseDeauthorizationBody(req);
+  if (!body) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Missing or invalid owner_id" }));
+    return;
+  }
+
+  const supabase = getSupabase();
+  try {
+    const { data: user, error: userError } = await supabase
+      .from("users")
+      .select("id")
+      .eq("strava_id", body.owner_id)
+      .maybeSingle();
+
+    if (userError) {
+      console.error("[webhook-server] deauthorization lookup failed (retryable)", {
+        owner_id: body.owner_id,
+        error: userError.message,
+      });
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: userError.message }));
+      return;
+    }
+
+    if (!user) {
+      console.log("[webhook-server] deauthorization skipped (user not found)", {
+        owner_id: body.owner_id,
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, skipped: true }));
+      return;
+    }
+
+    const { error: deleteError } = await supabase
+      .from("users")
+      .delete()
+      .eq("id", (user as { id: string }).id);
+
+    if (deleteError) {
+      console.error("[webhook-server] deauthorization delete failed (retryable)", {
+        owner_id: body.owner_id,
+        error: deleteError.message,
+      });
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: deleteError.message }));
+      return;
+    }
+
+    console.log("[webhook-server] deauthorization delete ok", { owner_id: body.owner_id });
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[webhook-server] deauthorization unexpected error (retryable)", {
+      owner_id: body.owner_id,
+      error: msg,
+    });
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: msg }));
+  }
 }
 
 async function handleUsersSync(req: IncomingMessage, res: ServerResponse): Promise<void> {
@@ -400,6 +475,8 @@ const server = createServer(async (req, res) => {
     await handleUsersSync(req, res);
   } else if (req.method === "POST" && path === PATH_USERS_INITIAL_BACKFILL) {
     await handleUsersInitialBackfill(req, res);
+  } else if (req.method === "POST" && path === PATH_WEBHOOK_DEAUTHORIZATION) {
+    await handleWebhookDeauthorization(req, res);
   } else if (req.method === "POST" && path === PATH_GROUPS) {
     await handleGroupsCreate(req, res);
   } else if (req.method === "POST" && path === PATH_GROUPS_JOIN) {
@@ -413,5 +490,6 @@ server.listen(PORT, () => {
   console.log(`Webhook server listening on http://localhost:${PORT}${PATH_WEBHOOK}`);
   console.log(`Users sync: http://localhost:${PORT}${PATH_USERS_SYNC}`);
   console.log(`Users initial backfill: http://localhost:${PORT}${PATH_USERS_INITIAL_BACKFILL}`);
+  console.log(`Webhook deauthorization: http://localhost:${PORT}${PATH_WEBHOOK_DEAUTHORIZATION}`);
   console.log(`Groups: http://localhost:${PORT}${PATH_GROUPS}, http://localhost:${PORT}${PATH_GROUPS_JOIN}`);
 });

--- a/client/app/api/strava/webhook/route.ts
+++ b/client/app/api/strava/webhook/route.ts
@@ -40,6 +40,10 @@ interface StravaWebhookPayload {
   owner_id?: number;
 }
 
+function getBackendBaseUrl(): string {
+  return process.env.BACKEND_API_URL?.replace(/\/$/, "") ?? "http://localhost:3001";
+}
+
 /**
  * Strava Webhook アクティビティ通知（POST）
  * object_type === 'activity' かつ aspect_type === 'create' のときは processActivityEvent、
@@ -59,31 +63,41 @@ export async function POST(request: NextRequest) {
 
   const { object_type, aspect_type, object_id, owner_id } = body;
 
-  if (
-    object_type !== "activity" ||
-    typeof object_id !== "number" ||
-    typeof owner_id !== "number"
-  ) {
-    return new NextResponse(null, { status: 200 });
-  }
+  const isActivityEvent =
+    object_type === "activity" &&
+    typeof object_id === "number" &&
+    typeof owner_id === "number" &&
+    (aspect_type === "create" || aspect_type === "delete");
 
-  const isDelete = aspect_type === "delete";
-  const isCreate = aspect_type === "create";
-
-  if (isCreate || isDelete) {
-    const baseUrl =
-      process.env.BACKEND_API_URL?.replace(/\/$/, "") ?? "http://localhost:3001";
-    const url = `${baseUrl}/webhook/activity`;
+  if (isActivityEvent) {
+    const url = `${getBackendBaseUrl()}/webhook/activity`;
     void fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         object_id,
         owner_id,
-        ...(isDelete ? { action: "delete" } : {}),
+        ...(aspect_type === "delete" ? { action: "delete" } : {}),
       }),
     }).catch((err) => {
-      console.error("[strava-webhook] backend fetch error:", err);
+      console.error("[strava-webhook] backend activity fetch error:", err);
+    });
+    return new NextResponse(null, { status: 200 });
+  }
+
+  const isDeauthorizationEvent =
+    object_type === "athlete" &&
+    typeof owner_id === "number" &&
+    (aspect_type === "update" || aspect_type === "delete");
+
+  if (isDeauthorizationEvent) {
+    const url = `${getBackendBaseUrl()}/webhook/deauthorization`;
+    void fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ owner_id }),
+    }).catch((err) => {
+      console.error("[strava-webhook] backend deauthorization fetch error:", err);
     });
   }
 

--- a/client/app/api/strava/webhook/route.ts
+++ b/client/app/api/strava/webhook/route.ts
@@ -92,13 +92,33 @@ export async function POST(request: NextRequest) {
 
   if (isDeauthorizationEvent) {
     const url = `${getBackendBaseUrl()}/webhook/deauthorization`;
-    void fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ owner_id }),
-    }).catch((err) => {
+
+    try {
+      const backendResponse = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ owner_id }),
+      });
+
+      if (!backendResponse.ok) {
+        const errorBody = await backendResponse.text();
+        console.error(
+          "[strava-webhook] backend deauthorization failed:",
+          backendResponse.status,
+          errorBody
+        );
+        return NextResponse.json(
+          { error: "Failed to process deauthorization event" },
+          { status: 500 }
+        );
+      }
+    } catch (err) {
       console.error("[strava-webhook] backend deauthorization fetch error:", err);
-    });
+      return NextResponse.json(
+        { error: "Failed to process deauthorization event" },
+        { status: 500 }
+      );
+    }
   }
 
   return new NextResponse(null, { status: 200 });


### PR DESCRIPTION
### Motivation
- Ensure Strava webhook deauthorization/update events (athlete deauth) are recognized and routed so revoked integrations can be cleaned up.
- Remove server-side stored Strava credentials and related rows by deleting the matching `users` row when an athlete deauthorizes, relying on existing FK cascade for related data.
- Document the new deauthorization flow and the Strava app callback URL to register for webhooks.

### Description
- Updated `client/app/api/strava/webhook/route.ts` to branch incoming POST payloads and forward activity events to `POST /webhook/activity` and athlete deauthorization/update events to `POST /webhook/deauthorization`, adding `getBackendBaseUrl()` helper.
- Added `POST /webhook/deauthorization` handler in `backend-api/src/webhook-server.ts` that parses `{ owner_id }`, looks up the user by `users.strava_id`, deletes the matching `users` row, logs retryable errors for lookup/delete failures, and returns `500` on retryable failures or `200` (with `{ ok: true, skipped: true }`) when no user exists.
- Extended `backend-api/openapi.yaml` with the `/webhook/deauthorization` path and `WebhookDeauthorizationRequest` schema.
- Updated `backend-api/README.md` to document the deauthorization endpoint, retry policy and the Strava app Callback URL to register (example: `https://<your-domain>/api/strava/webhook`).

### Testing
- Built the backend with `cd backend-api && npm run build`, which completed successfully.
- Ran unit tests with `cd backend-api && npm run test` (Vitest), and all tests passed (`38` tests across 4 files passed).
- Validated the OpenAPI spec with `cd backend-api && npm run openapi:lint`, which reported warnings but the specification validated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47977c23c832e8e7e0c6b1d76cf2d)