### PR TITLE
Await initial-backfill request in Strava OAuth callback

### DIFF
--- a/client/app/api/auth/strava/callback/route.ts
+++ b/client/app/api/auth/strava/callback/route.ts
@@ -128,18 +128,28 @@ export async function GET(request: NextRequest) {
   if (syncData.should_run_initial_backfill === true) {
     const internalBackfillApiKey = process.env.INTERNAL_BACKFILL_API_KEY ?? "";
     if (!internalBackfillApiKey) {
-      console.error("Initial backfill request skipped: INTERNAL_BACKFILL_API_KEY is not configured");
-    } else {
-      void fetch(`${backendUrl}/users/initial-backfill`, {
+      console.error("Initial backfill request failed: INTERNAL_BACKFILL_API_KEY is not configured");
+      return NextResponse.redirect(`${baseRedirect}/login?error=config`);
+    }
+
+    try {
+      const initialBackfillRes = await fetch(`${backendUrl}/users/initial-backfill`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           "x-internal-backfill-key": internalBackfillApiKey,
         },
         body: JSON.stringify({ strava_id: athlete.id }),
-      }).catch((e) => {
-        console.error("Initial backfill request failed:", e);
       });
+
+      if (!initialBackfillRes.ok) {
+        const text = await initialBackfillRes.text();
+        console.error("Initial backfill request failed:", initialBackfillRes.status, text);
+        return NextResponse.redirect(`${baseRedirect}/login?error=initial_backfill`);
+      }
+    } catch (e) {
+      console.error("Initial backfill request failed:", e);
+      return NextResponse.redirect(`${baseRedirect}/login?error=initial_backfill`);
     }
   }
 


### PR DESCRIPTION
### Motivation

- Ensure the one-time initial backfill is started reliably as part of the Strava OAuth callback completion so short-lived/serverless runtimes cannot terminate the request before the backfill begins.
- Fail fast when the internal backfill key is missing to avoid silently skipping required work.
- Surface errors from the backfill trigger to avoid completing login when the backfill did not start.

### Description

- Update `client/app/api/auth/strava/callback/route.ts` to `await` the `POST /users/initial-backfill` request instead of firing it with `void fetch(...)` so the call is part of the route completion path.
- Treat a missing `INTERNAL_BACKFILL_API_KEY` as an error and return a login redirect with `error=config` instead of silently skipping backfill.
- Add explicit error handling for non-2xx responses and thrown fetch errors from the initial-backfill request and return a login redirect with `error=initial_backfill` when those occur.

### Testing

- Backend unit tests for the earlier changes (`vitest` run against `backend-api/src/bff/users-sync.test.ts`) were previously run and passed.
- Attempted to run the client linter with `npm --prefix client run lint` but it could not complete non-interactively because ESLint prompted for first-time configuration, so the lint step did not finish in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47d13a580832ea18491d79b6b8d73)