### PR TITLE
Fix initial backfill window bounds and concurrency guard

### DIFF
--- a/backend-api/src/webhook-server.ts
+++ b/backend-api/src/webhook-server.ts
@@ -126,6 +126,7 @@ async function fetchRecentActivityIds(accessToken: string, days: number, baseTim
   while (true) {
     const params = new URLSearchParams({
       after: String(afterSec),
+      before: String(baseSec),
       per_page: String(perPage),
       page: String(page),
     });
@@ -211,7 +212,22 @@ async function handleUsersInitialBackfill(req: IncomingMessage, res: ServerRespo
     return;
   }
 
+  const lockTimestamp = new Date().toISOString();
   try {
+    const { data: claimRow, error: claimError } = await supabase
+      .from("users")
+      .update({ initial_backfill_done_at: lockTimestamp })
+      .eq("id", userRow.id)
+      .is("initial_backfill_done_at", null)
+      .select("id")
+      .maybeSingle();
+    if (claimError) throw new Error(claimError.message);
+    if (!claimRow) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, skipped: true }));
+      return;
+    }
+
     const activityIds = await fetchRecentActivityIds(token, 7, baseTime);
     const deps = createDefaultDeps(supabase, decryptStravaToken);
     for (const activityId of activityIds) {
@@ -220,11 +236,12 @@ async function handleUsersInitialBackfill(req: IncomingMessage, res: ServerRespo
       throw new Error(result.reason);
     }
 
-    const { error: updateError } = await supabase
+    const { error: completeError } = await supabase
       .from("users")
       .update({ initial_backfill_done_at: new Date().toISOString() })
-      .eq("id", userRow.id);
-    if (updateError) throw new Error(updateError.message);
+      .eq("id", userRow.id)
+      .eq("initial_backfill_done_at", lockTimestamp);
+    if (completeError) throw new Error(completeError.message);
 
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(
@@ -235,6 +252,15 @@ async function handleUsersInitialBackfill(req: IncomingMessage, res: ServerRespo
       })
     );
   } catch (err) {
+    const { error: releaseError } = await supabase
+      .from("users")
+      .update({ initial_backfill_done_at: null })
+      .eq("id", userRow.id)
+      .eq("initial_backfill_done_at", lockTimestamp);
+    if (releaseError) {
+      console.error("[webhook-server] users/initial-backfill lock release error:", releaseError);
+    }
+
     const msg = err instanceof Error ? err.message : String(err);
     console.error("[webhook-server] users/initial-backfill error:", err);
     res.writeHead(500, { "Content-Type": "application/json" });


### PR DESCRIPTION
### Motivation

- Ensure the initial backfill fetch only covers the intended 7-day window ending at `base_time` to avoid unintentionally processing a much larger activity set. 
- Prevent duplicate/overlapping side effects when two `/users/initial-backfill` requests run concurrently for the same user by making the backfill completion update atomic.

### Description

- Updated `backend-api/src/webhook-server.ts` `fetchRecentActivityIds` to include an upper bound by adding `before: String(baseSec)` to the Strava activities query parameters so the request is constrained to the intended window. 
- Added a claim step in `handleUsersInitialBackfill` that atomically updates `initial_backfill_done_at` to a `lockTimestamp` only when it is still `NULL`, returning `{ ok: true, skipped: true }` if the claim fails. 
- Tied the completion update to the claim by requiring the `initial_backfill_done_at` match the `lockTimestamp` when marking the backfill finished, and added a best-effort release of the claim (set to `NULL`) on processing errors to allow safe retries. 
- Kept existing activity processing (`processActivityEvent`) unchanged; only the fetch bounds and concurrency/claim semantics were modified in the webhook handler.

### Testing

- Built the backend with `npm --prefix backend-api run build` and the build completed successfully. 
- Ran the test suite with `npm --prefix backend-api test` and `vitest` completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47d12a398832e8c879920458d20a7)