### PR TITLE
Fix undefined STRAVA_AUTH_URL causing build failure

### DIFF
--- a/client/app/[locale]/login/page.tsx
+++ b/client/app/[locale]/login/page.tsx
@@ -2,6 +2,7 @@ import { LoginView } from "@/components/organisms/LoginView";
 import { getTranslations } from "next-intl/server";
 
 const STRAVA_LOGIN_ROUTE = "/api/auth/strava/login";
+const STRAVA_AUTH_URL = "https://www.strava.com/oauth/authorize";
 
 const LOGIN_ERROR_KEYS: Record<string, string> = {
   denied: "errorDenied",


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript build error (`Cannot find name 'STRAVA_AUTH_URL'`) that caused the deployment to fail after PR #48 by providing the missing Strava OAuth URL constant.

### Description
- Add `const STRAVA_AUTH_URL = "https://www.strava.com/oauth/authorize";` to `client/app/[locale]/login/page.tsx` so `buildStravaAuthUrl()` no longer references an undefined identifier.

### Testing
- Ran `cd client && npm run build`, which completed successfully (type-check and Next.js build finished) despite an intermittent Next.js lockfile patch network warning (`ENETUNREACH`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d9a60884832eaee6bc748e136e27)