### PR TITLE
Persist locale through Strava OAuth, localize redirects, and adjust connect button

### DIFF
--- a/client/app/[locale]/login/page.tsx
+++ b/client/app/[locale]/login/page.tsx
@@ -12,31 +12,24 @@ const LOGIN_ERROR_KEYS: Record<string, string> = {
   upsert: "errorUpsert",
   token_encryption: "errorTokenEncryption",
   state_mismatch: "errorStateMismatch",
+  initial_backfill: "errorInitialBackfill",
 };
 
-function buildStravaAuthUrl(): string {
-  const clientId = process.env.NEXT_PUBLIC_STRAVA_CLIENT_ID;
-  const appUrl = (process.env.NEXT_PUBLIC_APP_URL ?? "").replace(/\/$/, "") || "http://localhost:3000";
-  const redirectUri = `${appUrl}/api/auth/strava/callback`;
-  const scope = "read,activity:read";
-  const params = new URLSearchParams({
-    client_id: clientId ?? "",
-    redirect_uri: redirectUri,
-    response_type: "code",
-    scope,
-    approval_prompt: "auto",
-  });
-  return `${STRAVA_AUTH_URL}?${params.toString()}`;
-}
-
 export default async function LoginPage({
+  params,
   searchParams,
 }: {
+  params: Promise<{ locale: string }>;
   searchParams: Promise<{ error?: string }>;
 }) {
-  const { error } = await searchParams;
+  const [{ locale }, { error }] = await Promise.all([params, searchParams]);
   const t = await getTranslations("login");
   const errorMessage =
     error && LOGIN_ERROR_KEYS[error] ? t(LOGIN_ERROR_KEYS[error]) : null;
-  return <LoginView authUrl={STRAVA_LOGIN_ROUTE} errorMessage={errorMessage} />;
+  return (
+    <LoginView
+      authUrl={`${STRAVA_LOGIN_ROUTE}?locale=${encodeURIComponent(locale)}`}
+      errorMessage={errorMessage}
+    />
+  );
 }

--- a/client/app/api/auth/strava/callback/route.ts
+++ b/client/app/api/auth/strava/callback/route.ts
@@ -6,8 +6,10 @@ import {
 } from "@/lib/session";
 import {
   getStravaAuthStateDestroyOptions,
+  STRAVA_AUTH_LOCALE_COOKIE_NAME,
   STRAVA_AUTH_STATE_COOKIE_NAME,
 } from "@/lib/stravaAuthState";
+import { routing } from "@/i18n/routing";
 
 const STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token";
 
@@ -26,11 +28,9 @@ interface StravaTokenResponse {
 
 export async function GET(request: NextRequest) {
   const clearAuthState = (response: NextResponse): NextResponse => {
-    response.cookies.set(
-      STRAVA_AUTH_STATE_COOKIE_NAME,
-      "",
-      getStravaAuthStateDestroyOptions(),
-    );
+    const destroyOptions = getStravaAuthStateDestroyOptions();
+    response.cookies.set(STRAVA_AUTH_STATE_COOKIE_NAME, "", destroyOptions);
+    response.cookies.set(STRAVA_AUTH_LOCALE_COOKIE_NAME, "", destroyOptions);
     return response;
   };
 
@@ -39,29 +39,36 @@ export async function GET(request: NextRequest) {
   const error = searchParams.get("error");
   const receivedState = searchParams.get("state");
   const storedState = request.cookies.get(STRAVA_AUTH_STATE_COOKIE_NAME)?.value;
+  const storedLocale = request.cookies.get(STRAVA_AUTH_LOCALE_COOKIE_NAME)?.value;
 
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
   const baseRedirect = appUrl.replace(/\/$/, "") || "http://localhost:3000";
+  const locale =
+    storedLocale && routing.locales.includes(storedLocale as any)
+      ? storedLocale
+      : routing.defaultLocale;
+  const loginRedirectUrl = (errorKey: string): string =>
+    `${baseRedirect}/${locale}/login?error=${encodeURIComponent(errorKey)}`;
 
   if (error === "access_denied") {
-    return clearAuthState(NextResponse.redirect(`${baseRedirect}/login?error=denied`));
+    return clearAuthState(NextResponse.redirect(loginRedirectUrl("denied")));
   }
 
   if (!receivedState || !storedState || receivedState !== storedState) {
     console.warn("Strava OAuth state validation failed");
     return clearAuthState(
-      NextResponse.redirect(`${baseRedirect}/login?error=state_mismatch`),
+      NextResponse.redirect(loginRedirectUrl("state_mismatch")),
     );
   }
 
   if (!code) {
-    return clearAuthState(NextResponse.redirect(`${baseRedirect}/login?error=no_code`));
+    return clearAuthState(NextResponse.redirect(loginRedirectUrl("no_code")));
   }
 
   const clientId = process.env.NEXT_PUBLIC_STRAVA_CLIENT_ID;
   const clientSecret = process.env.STRAVA_CLIENT_SECRET;
   if (!clientId || !clientSecret) {
-    return clearAuthState(NextResponse.redirect(`${baseRedirect}/login?error=config`));
+    return clearAuthState(NextResponse.redirect(loginRedirectUrl("config")));
   }
 
   const body = new URLSearchParams({
@@ -83,7 +90,7 @@ export async function GET(request: NextRequest) {
       const text = await tokenRes.text();
       console.error("Strava token exchange failed:", tokenRes.status, text);
       return clearAuthState(
-        NextResponse.redirect(`${baseRedirect}/login?error=token_exchange`),
+        NextResponse.redirect(loginRedirectUrl("token_exchange")),
       );
     }
 
@@ -91,13 +98,13 @@ export async function GET(request: NextRequest) {
   } catch (e) {
     console.error("Strava token request error:", e);
     return clearAuthState(
-        NextResponse.redirect(`${baseRedirect}/login?error=token_exchange`),
-      );
+      NextResponse.redirect(loginRedirectUrl("token_exchange")),
+    );
   }
 
   const athlete = tokenData.athlete;
   if (!athlete?.id) {
-    return clearAuthState(NextResponse.redirect(`${baseRedirect}/login?error=no_athlete`));
+    return clearAuthState(NextResponse.redirect(loginRedirectUrl("no_athlete")));
   }
 
   const displayName = [athlete.firstname, athlete.lastname].filter(Boolean).join(" ") || `User ${athlete.id}`;
@@ -107,7 +114,7 @@ export async function GET(request: NextRequest) {
   const backendUrl = process.env.BACKEND_API_URL?.replace(/\/$/, "") ?? "";
   if (!backendUrl) {
     console.error("User sync failed: BACKEND_API_URL is not configured");
-    return clearAuthState(NextResponse.redirect(`${baseRedirect}/login?error=config`));
+    return clearAuthState(NextResponse.redirect(loginRedirectUrl("config")));
   }
 
   const syncPayload = {
@@ -128,13 +135,13 @@ export async function GET(request: NextRequest) {
     });
   } catch (e) {
     console.error("User sync request failed:", e);
-    return clearAuthState(NextResponse.redirect(`${baseRedirect}/login?error=upsert`));
+    return clearAuthState(NextResponse.redirect(loginRedirectUrl("upsert")));
   }
 
   if (!syncRes.ok) {
     const text = await syncRes.text();
     console.error("User sync failed:", syncRes.status, text);
-    return clearAuthState(NextResponse.redirect(`${baseRedirect}/login?error=upsert`));
+    return clearAuthState(NextResponse.redirect(loginRedirectUrl("upsert")));
   }
 
   let syncData: { id?: string; should_run_initial_backfill?: boolean };
@@ -142,19 +149,19 @@ export async function GET(request: NextRequest) {
     syncData = (await syncRes.json()) as { id?: string };
   } catch {
     console.error("User sync: invalid JSON response");
-    return clearAuthState(NextResponse.redirect(`${baseRedirect}/login?error=upsert`));
+    return clearAuthState(NextResponse.redirect(loginRedirectUrl("upsert")));
   }
 
   if (!syncData?.id) {
     console.error("User sync: response missing id");
-    return clearAuthState(NextResponse.redirect(`${baseRedirect}/login?error=upsert`));
+    return clearAuthState(NextResponse.redirect(loginRedirectUrl("upsert")));
   }
 
   if (syncData.should_run_initial_backfill === true) {
     const internalBackfillApiKey = process.env.INTERNAL_BACKFILL_API_KEY ?? "";
     if (!internalBackfillApiKey) {
       console.error("Initial backfill request failed: INTERNAL_BACKFILL_API_KEY is not configured");
-      return NextResponse.redirect(`${baseRedirect}/login?error=config`);
+      return clearAuthState(NextResponse.redirect(loginRedirectUrl("config")));
     }
 
     try {
@@ -170,16 +177,16 @@ export async function GET(request: NextRequest) {
       if (!initialBackfillRes.ok) {
         const text = await initialBackfillRes.text();
         console.error("Initial backfill request failed:", initialBackfillRes.status, text);
-        return NextResponse.redirect(`${baseRedirect}/login?error=initial_backfill`);
+        return clearAuthState(NextResponse.redirect(loginRedirectUrl("initial_backfill")));
       }
     } catch (e) {
       console.error("Initial backfill request failed:", e);
-      return NextResponse.redirect(`${baseRedirect}/login?error=initial_backfill`);
+      return clearAuthState(NextResponse.redirect(loginRedirectUrl("initial_backfill")));
     }
   }
 
   const token = await createSessionToken(syncData.id);
-  const response = NextResponse.redirect(baseRedirect);
+  const response = NextResponse.redirect(`${baseRedirect}/${locale}`);
   response.cookies.set(SESSION_COOKIE_NAME, token, getSessionCookieOptions());
   return clearAuthState(response);
 }

--- a/client/app/api/auth/strava/login/route.ts
+++ b/client/app/api/auth/strava/login/route.ts
@@ -1,14 +1,21 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import {
   generateStravaAuthState,
   getStravaAuthStateCookieOptions,
+  STRAVA_AUTH_LOCALE_COOKIE_NAME,
   STRAVA_AUTH_STATE_COOKIE_NAME,
 } from "@/lib/stravaAuthState";
+import { routing } from "@/i18n/routing";
 
 const STRAVA_AUTH_URL = "https://www.strava.com/oauth/authorize";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const state = generateStravaAuthState();
+  const requestedLocale = request.nextUrl.searchParams.get("locale");
+  const locale =
+    requestedLocale && routing.locales.includes(requestedLocale as any)
+      ? requestedLocale
+      : routing.defaultLocale;
   const clientId = process.env.NEXT_PUBLIC_STRAVA_CLIENT_ID;
   const appUrl =
     (process.env.NEXT_PUBLIC_APP_URL ?? "").replace(/\/$/, "") ||
@@ -26,10 +33,8 @@ export async function GET() {
   });
 
   const response = NextResponse.redirect(`${STRAVA_AUTH_URL}?${params.toString()}`);
-  response.cookies.set(
-    STRAVA_AUTH_STATE_COOKIE_NAME,
-    state,
-    getStravaAuthStateCookieOptions(),
-  );
+  const cookieOptions = getStravaAuthStateCookieOptions();
+  response.cookies.set(STRAVA_AUTH_STATE_COOKIE_NAME, state, cookieOptions);
+  response.cookies.set(STRAVA_AUTH_LOCALE_COOKIE_NAME, locale, cookieOptions);
   return response;
 }

--- a/client/components/atoms/StravaConnectButton.tsx
+++ b/client/components/atoms/StravaConnectButton.tsx
@@ -51,15 +51,27 @@ export function StravaConnectButton({
   className = "",
   "data-testid": dataTestId,
 }: StravaConnectButtonProps) {
-  return (
-    <Link
-      href={href}
-      className={`${baseClass} ${variantClasses[variant]} ${className}`.trim()}
-      data-testid={dataTestId ?? "connect-strava"}
-    >
+  const buttonClassName = `${baseClass} ${variantClasses[variant]} ${className}`.trim();
+  const testId = dataTestId ?? "connect-strava";
+  const content = (
+    <>
       <StravaLogoIcon className="h-5 w-5 shrink-0" />
       <span>{children}</span>
       {rightIcon}
+    </>
+  );
+
+  if (href.startsWith("/api/") || href.startsWith("http://") || href.startsWith("https://")) {
+    return (
+      <a href={href} className={buttonClassName} data-testid={testId}>
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} className={buttonClassName} data-testid={testId}>
+      {content}
     </Link>
   );
 }

--- a/client/lib/stravaAuthState.ts
+++ b/client/lib/stravaAuthState.ts
@@ -1,4 +1,5 @@
 const STRAVA_AUTH_STATE_COOKIE_NAME = "strava_oauth_state";
+const STRAVA_AUTH_LOCALE_COOKIE_NAME = "strava_oauth_locale";
 const STRAVA_AUTH_STATE_MAX_AGE_SEC = 60 * 10; // 10分
 
 export function generateStravaAuthState(): string {
@@ -37,4 +38,4 @@ export function getStravaAuthStateDestroyOptions(): {
   };
 }
 
-export { STRAVA_AUTH_STATE_COOKIE_NAME };
+export { STRAVA_AUTH_LOCALE_COOKIE_NAME, STRAVA_AUTH_STATE_COOKIE_NAME };

--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -92,7 +92,8 @@
     "errorNoAthlete": "Could not retrieve athlete information.",
     "errorUpsert": "Account registration failed.",
     "errorTokenEncryption": "Token encryption failed. Please ask the administrator to verify STRAVA_TOKEN_ENCRYPTION_KEY.",
-    "errorStateMismatch": "State validation failed. Please try signing in again."
+    "errorStateMismatch": "State validation failed. Please try signing in again.",
+    "errorInitialBackfill": "Initial data import failed. Please try again later."
   },
   "landing": {
     "tagline": "Run. Capture. Compete.",

--- a/client/messages/ja.json
+++ b/client/messages/ja.json
@@ -92,7 +92,8 @@
     "errorNoAthlete": "アスリート情報を取得できませんでした。",
     "errorUpsert": "アカウントの登録に失敗しました。",
     "errorTokenEncryption": "トークンの暗号化に失敗しました。管理者に STRAVA_TOKEN_ENCRYPTION_KEY の設定を確認してください。",
-    "errorStateMismatch": "認証状態の検証に失敗しました。もう一度お試しください。"
+    "errorStateMismatch": "認証状態の検証に失敗しました。もう一度お試しください。",
+    "errorInitialBackfill": "初回データ取り込みに失敗しました。時間をおいてもう一度お試しください。"
   },
   "landing": {
     "tagline": "Run. Capture. Compete.",


### PR DESCRIPTION
### Motivation
- Ensure the user's locale is preserved across the Strava OAuth flow so redirects and error pages return to the correct localized login.
- Surface and localize the initial backfill error path so users see a proper message if initial data import fails.
- Make the Strava connect button render correctly for API/external URLs to avoid client-side navigation issues.

### Description
- Persist locale in the Strava auth flow by adding `STRAVA_AUTH_LOCALE_COOKIE_NAME`, writing it in the login route, and clearing it together with the auth state when finishing auth, as implemented in `api/auth/strava/login/route.ts` and `api/auth/strava/callback/route.ts`.
- Validate and select locale using `routing.locales`/`routing.defaultLocale` and centralize localized login redirects with a `loginRedirectUrl` helper in the callback handler, and redirect to `/${locale}` after successful sign-in by setting the session cookie.
- Add `initial_backfill` to `LOGIN_ERROR_KEYS` and translation files (`client/messages/en.json` and `client/messages/ja.json`) with `errorInitialBackfill` messages.
- Update the login page to accept `params` and include the locale when invoking the Strava login endpoint by appending `?locale=` to the auth URL and remove the unused `buildStravaAuthUrl` helper.
- Update `StravaConnectButton` to render an `<a>` element for paths that start with `/api/` or external `http(s)` URLs and keep `Link` for internal app navigation, and refactor rendering to reuse `content`, `buttonClassName`, and `data-testid`.
- Export the new `STRAVA_AUTH_LOCALE_COOKIE_NAME` from `lib/stravaAuthState.ts` and reuse cookie options for both state and locale.

### Testing
- Performed a local build/type-check with `next build` and the project compiled successfully.
- Ran the test suite with `npm test` and all existing tests passed.
- Ran lint (`npm run lint`) and no new lint errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a095dd21444832e947e9b5a0169834f)